### PR TITLE
chore(github-actions): add pre-release and release configuration

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,51 @@
+name: Pre-release tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publich-dist-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        env :
+          CI: true
+        run: |
+          npm pkg delete scripts.prepare
+          npm ci
+
+      - name: Run eslint
+        run: |
+          npm run eslint
+
+      - name: Run unit tests
+        run: |
+          npm test
+
+      - name: Run build
+        run: |
+          npm run build
+
+      - name: Pre-release tag main 📦
+        if: success()
+        run: npm run release:ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pre-release main tag failed 🫣
+        if: failure()
+        run: |
+          echo "It seems something didn't go as planned 🤔"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release NPM Package
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          always-auth: true
+          registry-url: https://npm.pkg.github.com/
+          scope: '@srgssr'
+      - run: |
+          npm dist-tag ls @srgssr/pillarbox-web
+          npm dist-tag add @srgssr/pillarbox-web@$(npm view @srgssr/pillarbox-web dist-tags.main) latest
+          exit 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "type": "git",
     "url": "git+https://github.com/SRGSSR/pillarbox-web.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
   "devDependencies": {
     "@babel/core": "^7.22.5",
     "@babel/preset-env": "^7.22.5",


### PR DESCRIPTION
## Description

This PR automates the library delivery while ensuring that unit tests and linter tests pass beforehand.

## Changes made

- add github registry in `package.json` file
- add `pre-release` action
  - create change log
  - publish npm package to github registry
  - create github release note
- add `release` action
  - promote a pre-release to a release