### PR TITLE
chore(github-actions): rename pre-release job

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  publich-dist-tag:
+  publish-dist-tag:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

This PR fixes a typo in the `pre-release` action.

