### PR TITLE
chore(github-actions): add code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,11 @@
+name: Coverage
+on:
+    pull_request_target:
+        branches:
+            - main
+jobs:
+    coverage:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: ArtiomTr/jest-coverage-report-action@v2


### PR DESCRIPTION
## Description
Adds code `coverage` to `pull-requests`, in order to add it to Github `status checks`.
## Changes made
- add `coverage` workflow
