### PR TITLE
chore(github-action): add github page

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,11 @@
 name: Coverage
 on:
-    pull_request_target:
-        branches:
-            - main
+  pull_request_target:
+    branches:
+      - main
 jobs:
-    coverage:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: ArtiomTr/jest-coverage-report-action@v2
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ArtiomTr/jest-coverage-report-action@v2

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -1,0 +1,37 @@
+name: Github Page
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  github-page:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        env :
+          CI: true
+        run: |
+          npm pkg delete scripts.prepare
+          npm ci
+
+      - name: Run build Github Page
+        run: |
+          npm run github:page
+
+      - name: Deploy GitHub Page 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: dist

--- a/package.json
+++ b/package.json
@@ -2,14 +2,27 @@
   "name": "@srgssr/pillarbox-web",
   "description": "Pillarbox is the modern SRG SSR player",
   "version": "0.0.1",
-  "source": "src/pillarbox.js",
   "main": "dist/pillarbox.js",
+  "targets": {
+    "github-page": {
+      "publicUrl": "./",
+      "source": [
+        "demo/index.html"
+      ],
+      "isLibrary": false,
+      "outputFormat": "esmodule"
+    },
+    "main": {
+      "source": "src/pillarbox.js"
+    }
+  },
   "directories": {
     "doc": "docs"
   },
   "scripts": {
-    "build": "parcel build",
+    "build": "parcel build --target main",
     "eslint": "eslint --ext .js src",
+    "github:page": "parcel build --target github-page",
     "release:ci": "semantic-release",
     "start": "parcel -p 6969 demo/*.html",
     "test": "jest"


### PR DESCRIPTION
## Description

Adds the `github-page` workflow to generate the github page.

## Changes made

- add `parcel` build `targets` to the package.json
- add npm script to build the github page
- modify `build` script to point to build target `main`
- add `github-page` workflow
- update indentation in `coverage` workflow

