### PR TITLE
test(pillarbox): player initialization

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,18 +1,33 @@
 {
     "env": {
         "browser": true,
-        "es2021": true
+        "es2021": true,
+        "jest/globals": true
     },
+    "plugins": [
+        "jest"
+    ],
     "extends": [
         "eslint:recommended",
         "plugin:jest/recommended"
     ],
-    "overrides": [],
+    "overrides": [
+        {
+            "files": [
+                "test/**"
+            ],
+            "rules": {
+                "max-lines-per-function": "off",
+                "max-statements": "off"
+            }
+        }
+    ],
     "parserOptions": {
         "ecmaVersion": "latest",
         "sourceType": "module"
     },
     "rules": {
+        "jest/prefer-to-have-length": "warn",
         // https://eslint.org/docs/latest/rules/array-bracket-spacing
         "array-bracket-spacing": [
             "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^9.0.3",
         "@semantic-release/npm": "^10.0.4",
+        "@types/jest": "^29.5.3",
         "babel-jest": "^29.5.0",
         "buffer": "^6.0.3",
         "eslint": "^8.43.0",
@@ -6409,6 +6410,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.3.tgz",
+      "integrity": "sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jsdom": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^9.0.3",
     "@semantic-release/npm": "^10.0.4",
+    "@types/jest": "^29.5.3",
     "babel-jest": "^29.5.0",
     "buffer": "^6.0.3",
     "eslint": "^8.43.0",

--- a/test/pillarbox.spec.js
+++ b/test/pillarbox.spec.js
@@ -3,6 +3,20 @@ import { version } from '../package.json';
 import videojs from 'video.js';
 
 describe('Pillarbox', () => {
+  it('should create an instance of the component player', () => {
+    const videoEl = document.createElement('video');
+
+    videoEl.id = 'player';
+
+    document.body.appendChild(videoEl);
+
+    const pillarbox = new Pillarbox('player');
+
+
+    expect(pillarbox).toBeInstanceOf(Pillarbox.getComponent('Player'));
+    expect(pillarbox.id()).toEqual('player');
+  });
+
   describe('VERSION', () => {
     it('should contain the version provided by the package.json file', () => {
       expect(Pillarbox.VERSION.pillarbox).toEqual(version);


### PR DESCRIPTION
## Description

Adds a test case to ensure that when the `player` is created, the instance is a component of type `Player`.

## Changes made

- adds a test case for `player` initialization
- adds `types/jest` to dev dependencies to add autocompletion
- adapts `linter` rules for Jest

