### PR TITLE
feat: token-protected content playback

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -46,6 +46,10 @@ window.sourceExamples = {
   rts1: {
     src: 'urn:rts:video:3608506',
     type: 'srgssr/urn',
+  },
+  token: {
+    src: 'urn:rts:video:1967124',
+    type: 'srgssr/urn',
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@srgssr/pillarbox-web",
   "description": "Pillarbox is the modern SRG SSR player",
-  "version": "0.0.1",
+  "version": "0.0.7",
   "main": "dist/pillarbox.js",
   "targets": {
     "github-page": {

--- a/src/dataProvider/services/DataProviderService.js
+++ b/src/dataProvider/services/DataProviderService.js
@@ -17,6 +17,7 @@ class DataProviderService {
    *
    * @param {String} urn urn:rts:video:9800629
    * @param {Boolean} onlyChapters
+   *
    * @returns {Object} media composition json object
    */
   getMediaCompositionByUrn(urn, onlyChapters = false) {

--- a/src/utils/AkamaiTokenService.js
+++ b/src/utils/AkamaiTokenService.js
@@ -1,0 +1,143 @@
+const TOKEN_TYPES = {
+  AKAMAI: 'AKAMAI',
+  NONE: 'NONE',
+};
+
+class AkamaiTokenService {
+  /**
+   * Get the acl path.
+   *
+   * @param {URL} streamUrl
+   *
+   * @returns {String}
+   */
+  static aclPath(streamUrl) {
+    const path = streamUrl.pathname;
+
+    return `${path.substring(0, path.lastIndexOf('/') + 1)}*`;
+  }
+
+  /**
+   * AKAMAI
+   *
+   * @type {String}
+   */
+  static get AKAMAI() {
+    return TOKEN_TYPES.AKAMAI;
+  }
+
+  /**
+   * Check if the resources are protected by an Akamai token.
+   * Keep in mind, as we are using the some function,
+   * if the resources have at least one resource
+   * protected by a token it returns true!
+   *
+   * @param {Array.<Object>} resources
+   *
+   * @returns {Boolean}
+   */
+  static hasToken(resources) {
+    return resources.some((resource) =>
+      AkamaiTokenService.isAkamai(resource.tokenType));
+  }
+
+  /**
+   * Check if the token type is AKAMAI.
+   *
+   * @param {String} tokentype
+   *
+   * @returns {Boolean}
+   */
+  static isAkamai(tokentype) {
+    return TOKEN_TYPES.AKAMAI === tokentype;
+  }
+
+  /**
+   * Check if the token type is NONE.
+   *
+   * @param {String} tokentype
+   *
+   * @returns {Boolean}
+   */
+  static isNone(tokentype) {
+    return TOKEN_TYPES.NONE === tokentype;
+  }
+
+  /**
+   * NONE
+   *
+   * @type {String}
+   */
+  static get NONE() {
+    return TOKEN_TYPES.NONE;
+  }
+
+  /**
+   * Generate the stream URL with the akamai token.
+   *
+   * @param {String} source
+   * @param {String} tokenServerUrl
+   *
+   * @returns {Promise.<Object>}
+   */
+  static tokenize(source, tokenServerUrl) {
+    const streamUrlToTokenize = new URL(`${source.url}`);
+    const acl = AkamaiTokenService.aclPath(streamUrlToTokenize);
+    const url = `${tokenServerUrl}${encodeURIComponent(acl)}`;
+
+    return fetch(url)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        }
+
+        return Promise.reject({
+          status: response.status,
+          statusText: response.statusText,
+        });
+      })
+      .then(({ token: { authparams }}) => {
+        const akamaiAuthParams = new URLSearchParams(authparams);
+
+        akamaiAuthParams.forEach((v, k) =>
+          streamUrlToTokenize.searchParams.set(k, v));
+
+        return Object.assign({}, source, {
+          url: streamUrlToTokenize.toString(),
+        });
+      })
+      .catch((reason) => {
+        return Promise.reject(reason);
+      });
+  }
+
+  /**
+   * Generate a token for each source
+   *
+   * @param {Array} sources
+   * @param {String} tokenServerUrl
+   *
+   * @returns {Promise.<Array.<Object>>}
+   */
+  static tokenizeSources(
+    sources,
+    tokenServerUrl = 'https://tp.srgssr.ch/akahd/token?acl='
+  ) {
+    const tokenizedSources = [];
+
+    sources.forEach((source) => {
+      const tokenizedSource = AkamaiTokenService.tokenize(
+        source,
+        tokenServerUrl
+      );
+
+      tokenizedSources.push(tokenizedSource);
+    });
+
+    return Promise.all(tokenizedSources)
+      .then((values) => values)
+      .catch((reason) => Promise.reject(reason));
+  }
+}
+
+export default AkamaiTokenService;

--- a/test/__mocks__/streamTypeList.js
+++ b/test/__mocks__/streamTypeList.js
@@ -1,0 +1,68 @@
+const streamTypeList = [
+  {
+    dvr: true,
+    live: true,
+    streamType: 'DVR',
+    index: 0,
+    quality: 'HD',
+    tokenType: 'NONE',
+  },
+  {
+    dvr: false,
+    live: true,
+    streamType: 'LIVE',
+    index: 1,
+    quality: 'SD',
+    tokenType: 'AKAMAI',
+  },
+  {
+    dvr: false,
+    live: false,
+    streamType: 'ON_DEMAND',
+    index: 2,
+    quality: 'SD',
+    tokenType: 'AKAMAI',
+  },
+  {
+    dvr: false,
+    live: false,
+    streamType: 'ON_DEMAND',
+    index: 3,
+    quality: 'HQ',
+    tokenType: 'AKAMAI',
+  },
+  {
+    dvr: false,
+    live: true,
+    streamType: 'LIVE',
+    index: 4,
+    quality: 'HD',
+    tokenType: 'NONE',
+  },
+  {
+    dvr: false,
+    live: false,
+    streamType: 'ON_DEMAND',
+    index: 5,
+    quality: 'HD',
+    tokenType: 'NONE',
+  },
+  {
+    dvr: false,
+    live: true,
+    streamType: 'LIVE',
+    index: 6,
+    quality: 'HQ',
+    tokenType: 'AKAMAI',
+  },
+  {
+    dvr: true,
+    live: true,
+    streamType: 'DVR',
+    index: 7,
+    quality: 'SD',
+    tokenType: 'NONE',
+  }
+];
+
+export default streamTypeList;

--- a/test/utils/AkamaiTokenService.spec.js
+++ b/test/utils/AkamaiTokenService.spec.js
@@ -1,0 +1,162 @@
+import AkamaiTokenService from '../../src/utils/AkamaiTokenService.js';
+import streamTypeList from '../__mocks__/streamTypeList.js';
+
+window.fetch = jest.fn((source) => {
+  return Promise.resolve({
+    ok: source.includes('success'),
+    status: 503,
+    statusText: 'Service Unavailable',
+    json: () => {
+      if (source.includes('success')) {
+        return Promise.resolve({ token: { authparams: 'faketoken=123445' }});
+      }
+    },
+  });
+});
+
+describe('AkamaiTokenService', () => {
+  it('Getters are type of String', () => {
+    expect(AkamaiTokenService.AKAMAI).toEqual(expect.any(String));
+    expect(AkamaiTokenService.NONE).toEqual(expect.any(String));
+  });
+  /**
+   *****************************************************************************
+   * aclPath *******************************************************************
+   *****************************************************************************
+   */
+  describe('aclPath', () => {
+    it('should not match the pattern', () => {
+      const url = new URL(
+        'https://mock-token.ch/with/a/long/path/manifest.m3u8'
+      );
+
+      expect(AkamaiTokenService.aclPath(url)).toBe(
+        '/with/a/long/path/*'
+      );
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * hasToken ******************************************************************
+   *****************************************************************************
+   */
+  describe('hasToken', () => {
+    it('should return true if the resources are containing at least one resource protected by an AKAMAI token', () => {
+      const hasToken = true;
+
+      expect(AkamaiTokenService.hasToken(streamTypeList)).toBe(hasToken);
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * isAkamai ******************************************************************
+   *****************************************************************************
+   */
+  describe('isAkamai', () => {
+    it('should return true if the resource is protected by an AKAMAI token', () => {
+      streamTypeList.forEach((stream) => {
+        const { tokenType } = stream;
+        const hasToken = AkamaiTokenService.AKAMAI === tokenType;
+
+        expect(AkamaiTokenService.isAkamai(tokenType)).toBe(hasToken);
+      });
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * isNone ********************************************************************
+   *****************************************************************************
+   */
+  describe('isNone', () => {
+    it('should return true if the resource is not protected by an AKAMAI token', () => {
+      streamTypeList.forEach((stream) => {
+        const { tokenType } = stream;
+        const hasToken = AkamaiTokenService.NONE === tokenType;
+
+        expect(AkamaiTokenService.isNone(tokenType)).toBe(hasToken);
+      });
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * tokenize ******************************************************************
+   *****************************************************************************
+   */
+  describe('tokenize', () => {
+    it('should return a tokenized source', async () => {
+      const spyOnObject = jest.spyOn(Object, 'assign');
+
+      const result = await AkamaiTokenService.tokenize(
+        { url: 'https://mock-token.ch/with/a/long/path/manifest.m3u8' },
+        'https://success.token.server.ch'
+      );
+
+      expect(result).toMatchObject({
+        url: 'https://mock-token.ch/with/a/long/path/manifest.m3u8?faketoken=123445',
+      });
+      expect(spyOnObject).toHaveBeenCalled();
+    });
+
+    it('should be rejected if something went wrong', async () => {
+      await expect(
+        AkamaiTokenService.tokenize(
+          { url: 'https://mock-token.ch/with/a/long/path/manifest.m3u8' },
+          'https://unavailable.token.server.ch'
+        )
+      ).rejects.not.toBeNull();
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * tokenizeSources ***********************************************************
+   *****************************************************************************
+   */
+  describe('tokenizeSources', () => {
+    it('should return a tokenized sources', async () => {
+      const result = await AkamaiTokenService.tokenizeSources(
+        [
+          { url: 'https://mock-token.ch/with/a/long/path/manifest.m3u8' },
+          { url: 'https://mock-token.ch/with/a/long/path/manifest2.m3u8' }
+        ],
+        'https://success.token.server.ch'
+      );
+
+      expect(result).toMatchObject([
+        { url: 'https://mock-token.ch/with/a/long/path/manifest.m3u8?faketoken=123445' },
+        { url: 'https://mock-token.ch/with/a/long/path/manifest2.m3u8?faketoken=123445' }
+      ]);
+    });
+
+    it('should be rejected if something went wrong', async () => {
+      const spyOnTokenize = jest.spyOn(AkamaiTokenService, 'tokenize');
+
+      await expect(
+        AkamaiTokenService.tokenizeSources(
+          [
+            { url: 'https://mock-token.ch/with/a/long/path/manifest.m3u8' },
+            { url: 'https://mock-token.ch/with/a/long/path/manifest2.m3u8' }
+          ],
+          'https://unavailable.token.server.ch'
+        )
+      ).rejects.not.toBeNull();
+      expect(spyOnTokenize).toHaveBeenCalledWith(expect.anything(), 'https://unavailable.token.server.ch');
+    });
+
+    it('should be called with the default URL', async () => {
+      await expect(
+        AkamaiTokenService.tokenizeSources(
+          [
+            { url: 'https://mock-token.ch/with/a/long/path/manifest.m3u8' },
+            { url: 'https://mock-token.ch/with/a/long/path/manifest2.m3u8' }
+          ]
+        )
+      ).rejects.not.toBeNull();
+
+    });
+  });
+});


### PR DESCRIPTION
## Description

Resolves #28 and allows content protected by an Akamai token to be played.

## Changes made

- add `AkamaiTokenService` to hangle token generation
- update `SrgSsr` to handle token-protected resources
- update the demo
- update package.json `version`
- add test coverage

