### PR TITLE
feat(player): simplifies audio track handling

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -1,0 +1,49 @@
+import videojs from 'video.js';
+
+class Player extends videojs.getComponent('player') {
+  /**
+   * A getter/setter for the media's audio track.
+   * Activates the audio track according to the language and kind properties.
+   * Falls back on the first audio track found if the kind property is not satisfied.
+   *
+   * @param {TrackSelector} [trackSelector]
+   *
+   * @example
+   * // Get the current audio track
+   * player.audioTrack();
+   *
+   * @example
+   * // Activate an audio track based on language and kind properties
+   * player.audioTrack({language:'en', kind:'description'});
+   *
+   * @example
+   * // Activate first audio track found corresponding to language
+   * player.audioTrack({language:'fr'});
+   *
+   * @return { import('video.js/dist/types/tracks/audio-track').default|undefined }
+   */
+  audioTrack(trackSelector) {
+    const audioTracks = Array.from(this.player().audioTracks());
+
+    if (!trackSelector) {
+      return audioTracks.find((audioTrack) => audioTrack.enabled);
+    }
+
+    const { kind, language } = trackSelector;
+    const audioTrack =
+      audioTracks.find((audioTrack) => {
+        return (audioTrack.enabled =
+          audioTrack.language === language && audioTrack.kind === kind);
+      }) ||
+      audioTracks.find((audioTrack) => {
+        return (audioTrack.enabled = audioTrack.language === language);
+      });
+
+    return audioTrack;
+  }
+}
+
+// Overrides the default video.js player component
+videojs.registerComponent('player', Player);
+
+export default Player;

--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -1,6 +1,7 @@
 import { version } from '../package.json';
 import videojs from 'video.js';
 import 'videojs-contrib-eme';
+import './components/player.js';
 
 /**
  * @namespace

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -1,0 +1,6 @@
+/**
+ * @typedef {Object} TrackSelector The track to select
+ *
+ * @property {String} language The track language
+ * @property {String} kind The track kind
+ */

--- a/test/components/player.spec.js
+++ b/test/components/player.spec.js
@@ -1,0 +1,64 @@
+import Player from '../../src/components/player.js';
+
+describe('Player', () => {
+  const videoEl = document.createElement('video');
+
+  videoEl.id = 'mock-player';
+
+  describe('audioTrack', () => {
+    const player = new Player(videoEl);
+
+    player.audioTracks = jest.fn(() => ({
+      0: {
+        enabled: true,
+        id: '1',
+        kind: 'main',
+        label: 'English',
+        language: 'en',
+      },
+      1: {
+        enabled: false,
+        id: '2',
+        kind: 'alternative',
+        label: 'English alternative',
+        language: 'en',
+      },
+      length: 2,
+    }));
+
+    it('should return the currently active audio track if the function parameter is undefined', () => {
+      expect(player.audioTrack()).toMatchObject({
+        enabled: true,
+        id: '1',
+        kind: 'main',
+        label: 'English',
+        language: 'en',
+      });
+    });
+    it('should enable and return the audio track according to the language and kind properties', () => {
+      expect(
+        player.audioTrack({ language: 'en', kind: 'alternative' })
+      ).toMatchObject({
+        enabled: true,
+        id: '2',
+        kind: 'alternative',
+        label: 'English alternative',
+        language: 'en',
+      });
+    });
+    it('should enable and return the audio track according to the language property if the kind property does not satisfy the condition', () => {
+      expect(
+        player.audioTrack({ language: 'en', kind: 'invalid' })
+      ).toMatchObject({
+        enabled: true,
+        id: '1',
+        kind: 'main',
+        label: 'English',
+        language: 'en',
+      });
+    });
+    it('should return undefined if the language and kind properties do not satisfy the condition', () => {
+      expect(player.audioTrack({ language: 'fr' })).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Resolves #38 by adding the `audioTrack` function to simplify audio track retrieval and selection. This function allows to:

- retrieve the currently active audio track
- activate an audio track based on `language` and `kind` properties

Also, when selecting an audio track, if the `kind` property is not satisfied, the first audio track satisfying the `language` condition will be returned, or `undefined` if no condition is satisfied.

```javascript
// Get the current audio track
player.audioTrack();

// Activate an audio track
player.audioTrack({language:'en', kind:'alternative'})
```

## Changes made

- redefine default video.js `player` component
- add `audioTrack` function
- add a `typedefs` file to keep all types
- add `trackSelector` type representing the track to be selected
- add test coverage
