### PR TITLE
chore(npm): update video.js to v8.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
-        "video.js": "^8.5.3",
+        "video.js": "^8.6.1",
         "videojs-contrib-eme": "^3.11.1"
       },
       "devDependencies": {
@@ -7238,17 +7238,17 @@
       }
     },
     "node_modules/@videojs/http-streaming": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.5.3.tgz",
-      "integrity": "sha512-dty8lsZk9QPc0i4It79tjWsmPiaC3FpgARFM0vJGko4k3yKNZIYkAk8kjiDRfkAQH/HZ3rYi5dDTriFNzwSsIg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.7.0.tgz",
+      "integrity": "sha512-5uLFKBL8CvD56dxxJyuxqB5CY0tdoa4SE9KbXakeiAy6iFBUEPvTr2YGLKEWvQ8Lojs1wl+FQndLdv+GO7t9Fw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",
         "aes-decrypter": "4.0.1",
         "global": "^4.4.0",
         "m3u8-parser": "^7.1.0",
-        "mpd-parser": "^1.1.1",
-        "mux.js": "7.0.0",
+        "mpd-parser": "^1.2.2",
+        "mux.js": "7.0.1",
         "video.js": "^7 || ^8"
       },
       "engines": {
@@ -7277,22 +7277,6 @@
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0",
         "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/mux.js": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.0.tgz",
-      "integrity": "sha512-DeZmr+3NDrO02k4SREtl4VB5GyGPCz2fzMjDxBIlamkxffSTLge97rtNMoonnmFHTp96QggDucUtKv3fmyObrA==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "global": "^4.4.0"
-      },
-      "bin": {
-        "muxjs-transmux": "bin/transmux.js"
       },
       "engines": {
         "node": ">=8",
@@ -14682,9 +14666,9 @@
       }
     },
     "node_modules/mux.js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.3.0.tgz",
-      "integrity": "sha512-/QTkbSAP2+w1nxV+qTcumSDN5PA98P0tjrADijIzQHe85oBK3Akhy9AHlH0ne/GombLMz1rLyvVsmrgRxoPDrQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.1.tgz",
+      "integrity": "sha512-Omz79uHqYpMP1V80JlvEdCiOW1hiw4mBvDh9gaZEpxvB+7WYb2soZSzfuSRrK2Kh9Pm6eugQNrIpY/Bnyhk4hw==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "global": "^4.4.0"
@@ -23617,12 +23601,12 @@
       }
     },
     "node_modules/video.js": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.5.3.tgz",
-      "integrity": "sha512-P09Fl4mS13YGYCu4XkUtPoYOAPuRhCTMi34cQW+Xj9jEv8Gqi/Tf4mUl2jg9LTOib+N/hvcuH8XAWEJelilKxw==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.6.1.tgz",
+      "integrity": "sha512-CNYVJ5WWIZ7bOhbkkfcKqLGoc6WsE3Ft2RfS1lXdQTWk8UiSsPW2Ssk2JzPCA8qnIlUG9os/faCFsYWjyu4JcA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "3.5.3",
+        "@videojs/http-streaming": "3.7.0",
         "@videojs/vhs-utils": "^4.0.0",
         "@videojs/xhr": "2.6.0",
         "aes-decrypter": "^4.0.1",
@@ -23630,7 +23614,7 @@
         "keycode": "2.2.0",
         "m3u8-parser": "^6.0.0",
         "mpd-parser": "^1.0.1",
-        "mux.js": "^6.2.0",
+        "mux.js": "^7.0.1",
         "safe-json-parse": "4.0.0",
         "videojs-contrib-quality-levels": "4.0.0",
         "videojs-font": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "stylelint-order": "^6.0.3"
   },
   "dependencies": {
-    "video.js": "^8.5.3",
+    "video.js": "^8.6.1",
     "videojs-contrib-eme": "^3.11.1"
   }
 }


### PR DESCRIPTION
## Description

This PR update video.js to version [8.6.1](https://github.com/videojs/video.js/releases/tag/v8.6.1) 

## Changes made

- update package.json file

