### PR TITLE
fix(pillarbox): eme plugin name does not survive minification

### DIFF
--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -16,7 +16,7 @@ class Pillarbox extends videojs {
       pillarbox: version,
       videojs: videojs.VERSION,
       [videojs.VhsSourceHandler.name]: videojs.VhsSourceHandler.VERSION,
-      [videojs.getPlugin('eme').name]: videojs.getPlugin('eme').VERSION,
+      eme: videojs.getPlugin('eme').VERSION,
     };
   }
 }


### PR DESCRIPTION
## Description

In the `VERSION` property, when `parceljs` performs minification the plugin name is changed to a random value.

## Changes made

- set the `eme` key manually instead of using `videojs.getPlugin('eme').name`

