### PR TITLE
fix(player): audio track disabled if no selection criteria met

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -6,6 +6,9 @@ class Player extends videojs.getComponent('player') {
    * Activates the audio track according to the language and kind properties.
    * Falls back on the first audio track found if the kind property is not satisfied.
    *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack/kind
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack/language
+   *
    * @param {TrackSelector} [trackSelector]
    *
    * @example
@@ -31,13 +34,14 @@ class Player extends videojs.getComponent('player') {
 
     const { kind, language } = trackSelector;
     const audioTrack =
-      audioTracks.find((audioTrack) => {
-        return (audioTrack.enabled =
-          audioTrack.language === language && audioTrack.kind === kind);
-      }) ||
-      audioTracks.find((audioTrack) => {
-        return (audioTrack.enabled = audioTrack.language === language);
-      });
+      audioTracks.find(
+        (audioTrack) =>
+          audioTrack.language === language && audioTrack.kind === kind
+      ) || audioTracks.find((audioTrack) => audioTrack.language === language);
+
+    if (audioTrack) {
+      audioTrack.enabled = true;
+    }
 
     return audioTrack;
   }
@@ -47,6 +51,9 @@ class Player extends videojs.getComponent('player') {
    * Activates the text track according to the language and kind properties.
    * Falls back on the first text track found if the kind property is not satisfied.
    * Disables all subtitle tracks that are `showing` if the `trackSelector` is truthy but does not satisfy any condition.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/TextTrack/kind
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/textTrack/language
    *
    * @param {TrackSelector} [trackSelector]
    *

--- a/test/components/player.spec.js
+++ b/test/components/player.spec.js
@@ -57,8 +57,9 @@ describe('Player', () => {
         language: 'en',
       });
     });
-    it('should return undefined if the language and kind properties do not satisfy the condition', () => {
+    it('should return undefined and not disable the already active audio track if the language and kind properties do not satisfy the condition', () => {
       expect(player.audioTrack({ language: 'fr' })).toBeUndefined();
+      expect(player.audioTracks.mock.results[0].value[0].enabled).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Description

When changing the audio track, if the parameter passed to the `audioTrack` function does not match to any audio track, the audio track already enabled is disabled.

## Changes made

- update audio track activation condition
- add documentation links
- update test case