### PR TITLE
feat(srgssr-middleware): add support for SRG SSR blocking reasons

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -7,8 +7,8 @@ import SRGAnalytics from '../analytics/SRGAnalytics.js';
 
 class SrgSsr {
   /**
-   * Set a blocking reason according
-   * the block reason returned by mediaData.
+   * Set a blocking reason according to the block reason returned
+   * by mediaData.
    *
    * @param {VideoJsPlayer} player
    * @param {String} blockReason

--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -27,4 +27,16 @@ Pillarbox.options.srgOptions = {
 };
 Pillarbox.options.trackers = {};
 
+// TODO will be moved, see https://github.com/SRGSSR/pillarbox-web/issues/48
+Pillarbox.addLanguage('en', {
+  AGERATING12: 'To protect children this content is only available between 8PM and 6AM.',
+  AGERATING18: 'To protect children this content is only available between 10PM and 5AM.',
+  COMMERCIAL: 'This commercial content is not available.',
+  ENDDATE: 'This content is not available anymore.',
+  GEOBLOCK: 'This content is not available outside Switzerland.',
+  LEGAL: 'This content is not available due to legal restrictions.',
+  STARTDATE: 'This content is not available yet.',
+  UNKNOWN: 'This content is not available.',
+});
+
 export default Pillarbox;


### PR DESCRIPTION
## Description

Resolves #39 by adding support for blocking reasons to prevent content from being played.

## Changes made

- add error messages for blocking reasons in `pillarbox`
- add logic to `setSource` to display an `error` if content has a `blockingReason`
- add test coverage

