### PR TITLE
fix(analytics): use new textrack API

### DIFF
--- a/src/analytics/SRGAnalytics.js
+++ b/src/analytics/SRGAnalytics.js
@@ -286,9 +286,7 @@ class SRGAnalytics {
    * @returns {String} empty string or uppercase language.
    */
   getCurrentTextTrack() {
-    const currentTrack = Array.from(this.player.textTracks())
-      .filter((track) => track.kind !== 'metadata')
-      .find((track) => track.mode === 'showing');
+    const currentTrack = this.player.textTrack();
     let language = 'und';
 
     if (currentTrack && !!currentTrack.language) {

--- a/test/analytics/srg-analytics.spec.js
+++ b/test/analytics/srg-analytics.spec.js
@@ -84,7 +84,7 @@ describe('SRGAnalytics', () => {
     tech: jest.fn().mockReturnValue({
       isCasting: undefined,
     }),
-    textTracks: jest.fn().mockReturnValue({}),
+    textTrack: jest.fn().mockReturnValue(undefined),
     trigger: jest.fn((evt) => {
       document.dispatchEvent(new Event(evt));
     }),
@@ -393,32 +393,17 @@ describe('SRGAnalytics', () => {
    *****************************************************************************
    */
   describe('getCurrentTextTrack', () => {
-    it('should return an empty string if no audio track is enabled', () => {
+    it('should return an empty string if no text track is enabled', () => {
       expect(analytics.getCurrentTextTrack()).toBeFalsy();
     });
 
-    it('should return an upper case string representing the audio language', () => {
-      player.textTracks = jest.fn(() => ({
-        0: {
+    it('should return an upper case string representing the text language', () => {
+      player.textTrack.mockReturnValueOnce({
           kind: 'subtitle',
           language: 'fr',
           label: 'Français',
           mode: 'showing',
-        },
-        1: {
-          kind: 'subtitle',
-          language: 'en',
-          label: 'English',
-          mode: 'hidden',
-        },
-        2: {
-          kind: 'metadata',
-          language: 'whatever',
-          label: 'we-dont-care',
-          mode: 'god',
-        },
-        length: 3,
-      }));
+      });
 
       expect(analytics.getCurrentTextTrack()).toBe('FR');
     });


### PR DESCRIPTION
## Description

Closes #52

The SRGAnalytics class was still using the videojs `textTracks`.

## Changes made

This fix substitutes it for the newly introduced `textTrack` which already filters the subtitles by show status and excludes any subtitle labelled as `metadata` or `chapter`.