### PR TITLE
feat(demo): Add a demo page with example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
+### Compiled output ###
 node_modules
+
+### Compiled output ###
 .parcel-cache
 dist
 coverage
+
+### IntelliJ IDEA ###
+.idea
+*.iml
+*.iws
+*.ipr

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,17 +11,22 @@
   </head>
 
   <body>
-    <h1>Pillarbox@<span class="version"></span></h1>
+  <!-- Dialog with the player -->
+  <dialog id="pbw-dialog">
+    <a id="pbw-dialog-close-btn" class="btn-link dialog-close-btn" href="#">&times;</a>
+    <video-js id="player" class="pbw-demo" controls crossorigin="anonymous"></video-js>
+  </dialog>
 
-    <div class="container">
-      <video-js
-        id="player"
-        class="pbw-demo"
-        controls
-        crossorigin="anonymous"
-      ></video-js>
-    </div>
+  <!-- Main page -->
+  <h1>Pillarbox@<span class="version"></span></h1>
 
-    <script type="module" src="src/index.js"></script>
+  <div class="container">
+    <input type="text" id="search-bar" placeholder="Load any URL or URN...">
+
+    <!-- List of examples -->
+    <div id="examples"></div>
+  </div>
+
+  <script type="module" src="src/index.js"></script>
   </body>
 </html>

--- a/demo/scss/dialog.scss
+++ b/demo/scss/dialog.scss
@@ -1,0 +1,27 @@
+dialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+#pbw-dialog {
+  width: 100%;
+  max-width: 640px;
+  height: 100%;
+  max-height: 360px;
+  padding: 0;
+  overflow: visible;
+  background-color: var(--gray-12);
+}
+
+.dialog-close-btn {
+  position: absolute;
+  top: -15px;
+  right: 0px;
+  z-index: 1;
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
+  border-radius: 50%;
+}
+
+

--- a/demo/scss/examples.scss
+++ b/demo/scss/examples.scss
@@ -1,0 +1,12 @@
+#examples {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.example-btn {
+  width: 100%;
+  margin: 10px;
+  padding: 20px 0;
+}

--- a/demo/scss/index.scss
+++ b/demo/scss/index.scss
@@ -7,8 +7,6 @@
 body {
   display: grid;
 
-  min-height: 100vh;
-
   margin: 0;
   color: var(--gray-0);
   font-size: var(--size-5);
@@ -28,10 +26,45 @@ h1 {
 }
 
 .container {
-  width: 640px;
-  height: 360px;
+  margin: 10px;
 }
 
 .pbw-demo {
   font-size: 15px;
 }
+
+#search-bar {
+  width: 100%;
+  margin: 10px 0;
+  padding: 10px;
+  color: #fff;
+  font-size: 16px;
+  background-color: #333;
+  border: none;
+  border-radius: 5px;
+  outline: none;
+}
+
+#search-bar::placeholder {
+  color: #888;
+}
+
+.btn-link {
+  color: #fff;
+  text-align: center;
+  text-decoration: none;
+  background-color: #333;
+  border: 1px solid #444;
+  border-radius: 5px;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.btn-link:hover {
+  background-color: #444;
+  border-color: #555;
+}
+
+@import "dialog";
+@import "examples";
+
+

--- a/demo/src/ExampleDialog.js
+++ b/demo/src/ExampleDialog.js
@@ -1,0 +1,28 @@
+import Pillarbox from '../../src/pillarbox';
+
+const dialog = document.getElementById('pbw-dialog');
+
+// Pauses de video once the modal is closed.
+dialog.addEventListener('close', () => Pillarbox.getPlayer('player').pause());
+
+// Close the dialog on close button clicked
+dialog.querySelector('#pbw-dialog-close-btn').addEventListener('click', () => dialog.close());
+
+/**
+ * Opens a modal containing a video player with specified source and type. Can only
+ * load URN if the type 'srgssr/urn`is explicitly provided, otherwise the created
+ * Pillarbox player tries to guess the type.
+ *
+ * @param {object} options - An object containing the source and type of the video to be played.
+ * @param {string} options.src - The source URL of the video.
+ * @param {string} [options.type] - (Optional) The type/format of the video (e.g., 'video/mp4').
+ */
+export const openModal = async ({ src, type }) => {
+  const player = Pillarbox.getPlayer('player');
+
+  if (player.currentSrc() !== src) {
+    player.src({ src, type });
+  }
+
+  dialog.showModal();
+};

--- a/demo/src/Examples.js
+++ b/demo/src/Examples.js
@@ -1,0 +1,311 @@
+export const EXAMPLES = [
+  {
+    'title': 'VOD - HLS',
+    'description': 'Switzerland says sorry! The fondue invasion',
+    'src': 'https://swi-vod.akamaized.net/videoJson/47603186/master.m3u8'
+  },
+  {
+    'title': 'VOD - HLS (short)',
+    'description': 'Des violents orages ont touché Ajaccio, chef-lieu de la Corse, jeudi',
+    'src': 'https://rts-vod-amd.akamaized.net/ww/13317145/f1d49f18-f302-37ce-866c-1c1c9b76a824/master.m3u8'
+  },
+  {
+    'title': 'VOD - MP4',
+    'description': 'The dig',
+    'src': 'https://media.swissinfo.ch/media/video/dddaff93-c2cd-4b6e-bdad-55f75a519480/rendition/154a844b-de1d-4854-93c1-5c61cd07e98c.mp4'
+  },
+  {
+    'title': 'Brain Farm Skate Phantom Flex',
+    'description': '4K video',
+    'src': 'https://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8'
+  },
+  {
+    'title': 'Video livestream - HLS',
+    'description': 'Couleur 3 en vidéo (live)',
+    'src': 'https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0'
+  },
+  {
+    'title': 'Video livestream with DVR - HLS',
+    'description': 'Couleur 3 en vidéo (DVR)',
+    'src': 'https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8'
+  },
+  {
+    'title': 'Video livestream with DVR and timestamps - HLS',
+    'description': 'Tageschau',
+    'src': 'https://tagesschau.akamaized.net/hls/live/2020115/tagesschau/tagesschau_1/master.m3u8'
+  },
+  {
+    'title': 'AOD - MP3',
+    'description': 'On en parle',
+    'src': 'https://rts-aod-dd.akamaized.net/ww/13306839/63cc2653-8305-3894-a448-108810b553ef.mp3'
+  },
+  {
+    'title': 'Audio livestream - MP3',
+    'description': 'Couleur 3 (live)',
+    'src': 'https://stream.srg-ssr.ch/m/couleur3/mp3_128'
+  },
+  {
+    'title': 'Audio livestream - HLS',
+    'description': 'Couleur 3 (DVR)',
+    'src': 'https://lsaplus.swisstxt.ch/audio/couleur3_96.stream/playlist.m3u8'
+  },
+  {
+    'title': 'Apple Basic 4:3',
+    'description': '4x3 aspect ratio, H.264 @ 30Hz',
+    'src': 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8'
+  },
+  {
+    'title': 'Apple Basic 16:9',
+    'description': '16x9 aspect ratio, H.264 @ 30Hz',
+    'src': 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8'
+  },
+  {
+    'title': 'Apple Advanced 16:9 (TS)',
+    'description': '16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Transport stream',
+    'src': 'https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8'
+  },
+  {
+    'title': 'Apple Advanced 16:9 (fMP4)',
+    'description': '16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Fragmented MP4',
+    'src': 'https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8'
+  },
+  {
+    'title': 'Apple Advanced 16:9 (HEVC/H.264)',
+    'description': '16x9 aspect ratio, H.264 and HEVC @ 30Hz and 60Hz',
+    'src': 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8'
+  },
+  {
+    'title': 'Apple Atmos',
+    'src': 'https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8'
+  },
+  {
+    'title': 'Apple WWDC Keynote 2023',
+    'src': 'https://events-delivery.apple.com/0105cftwpxxsfrpdwklppzjhjocakrsk/m3u8/vod_index-PQsoJoECcKHTYzphNkXohHsQWACugmET.m3u8'
+  },
+  {
+    'title': 'Apple tv trailer',
+    'description': 'Lot of audios and subtitles choices',
+    'src': 'https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1522121579&isExternal=true&brandId=tvs.sbd.4000&id=518077009&l=en-GB&aec=UHD\n'
+  },
+  {
+    'title': 'VoD - Dash (H264)',
+    'src': 'https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd'
+  },
+  {
+    'title': 'VoD - Dash Widewine cenc (H264)',
+    'src': 'https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd',
+    'licenseUrl': 'https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test'
+  },
+  {
+    'title': 'VoD - Dash (H265)',
+    'src': 'https://storage.googleapis.com/wvmedia/clear/hevc/tears/tears.mpd'
+  },
+  {
+    'title': 'VoD - Dash widewine cenc (H265)',
+    'src': 'https://storage.googleapis.com/wvmedia/cenc/hevc/tears/tears.mpd',
+    'licenseUrl': 'https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test'
+  },
+  {
+    'title': 'Horizontal video',
+    'src': 'urn:rts:video:6820736',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'Square video',
+    'src': 'urn:rts:video:8393241',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'Vertical video',
+    'src': 'urn:rts:video:13444390',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'Token-protected video',
+    'description': 'Ski alpin, Slalom Messieurs',
+    'src': 'urn:swisstxt:video:rts:c56ea781-99ad-40c3-8d9b-444cc5ac3aea',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'Superfluously token-protected video',
+    'description': 'Telegiornale flash',
+    'src': 'urn:rsi:video:15916771',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'DRM-protected video',
+    'description': 'Top Models 8870',
+    'src': 'urn:rts:video:13639837',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'Live video',
+    'description': 'SRF 1',
+    'src': 'urn:srf:video:c4927fcf-e1a0-0001-7edd-1ef01d441651',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'DVR video livestream',
+    'description': 'RTS 1',
+    'src': 'urn:rts:video:3608506',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'DVR audio livestream',
+    'description': 'Couleur 3 (DVR)',
+    'src': 'urn:rts:audio:3262363',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'On-demand audio stream',
+    'description': 'Il lavoro di TerraProject per una fotografia documentaria',
+    'src': 'urn:rsi:audio:8833144',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'Expired URN',
+    'description': 'Content that is not available anymore',
+    'src': 'urn:rts:video:13382911',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'Unknown URN',
+    'description': 'Content that does not exist',
+    'src': 'urn:srf:video:unknown',
+    'type': 'srgssr/urn'
+  },
+  {
+    'title': 'Multiple subtitles and audio tracks',
+    'description': 'On some devices codec may crash',
+    'src': 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8'
+  },
+  {
+    'title': '4K, HEVC',
+    'src': 'https://cdn.bitmovin.com/content/encoding_test_dash_hls/4k/hls/4k_profile/master.m3u8'
+  },
+  {
+    'title': 'VoD, single audio track',
+    'src': 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+  },
+  {
+    'title': 'AES-128',
+    'src': 'https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8'
+  },
+  {
+    'title': 'AVC Progressive',
+    'src': 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4'
+  },
+  {
+    'title': 'HLS - Fragmented MP4',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8'
+  },
+  {
+    'title': 'HLS - Alternate audio language',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.m3u8'
+  },
+  {
+    'title': 'HLS - Audio only',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.m3u8?filter=(type!=%22video%22)'
+  },
+  {
+    'title': 'HLS - Trickplay',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/no-handler-origin/tears-of-steel/tears-of-steel-trickplay.m3u8'
+  },
+  {
+    'title': 'Limiting bandwidth use',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8?max_bitrate=800000'
+  },
+  {
+    'title': 'Dynamic Track Selection',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8?filter=%28type%3D%3D%22audio%22%26%26systemBitrate%3C100000%29%7C%7C%28type%3D%3D%22video%22%26%26systemBitrate%3C1024000%29'
+  },
+  {
+    'title': 'Pure live',
+    'src': 'https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8'
+  },
+  {
+    'title': 'Timeshift (5 minutes)',
+    'src': 'https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8?time_shift=300'
+  },
+  {
+    'title': 'Live audio',
+    'src': 'https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8?filter=(type!=%22video%22)'
+  },
+  {
+    'title': 'Pure live (scte35)',
+    'src': 'https://demo.unified-streaming.com/k8s/live/stable/scte35.isml/.m3u8'
+  },
+  {
+    'title': 'fMP4, clear',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-fmp4.ism/.m3u8'
+  },
+  {
+    'title': 'fMP4, HEVC 4K',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-hevc.ism/.m3u8'
+  },
+  {
+    'title': 'Dash - MP4',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.mp4/.mpd'
+  },
+  {
+    'title': 'Dash - Fragmented MP4',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.mpd'
+  },
+  {
+    'title': 'Dash - TrickPlay',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/no-handler-origin/tears-of-steel/tears-of-steel-trickplay.mpd'
+  },
+  {
+    'title': 'Dash - Tiled thumbnails (live/timeline)',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-tiled-thumbnails-timeline.ism/.mpd'
+  },
+  {
+    'title': 'Dash - Accessibility - hard of hearing',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-hoh-subs.ism/.mpd'
+  },
+  {
+    'title': 'Dash - Single - fragmented TTML',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-en.ism/.mpd'
+  },
+  {
+    'title': 'Dash - Multiple - RFC 5646 language tags',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-rfc5646.ism/.mpd'
+  },
+  {
+    'title': 'Dash - Multiple - fragmented TTML',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-ttml.ism/.mpd'
+  },
+  {
+    'title': 'Dash - Audio only',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.mpd?filter=(type!=%22video%22)'
+  },
+  {
+    'title': 'Dash - Multiple audio codecs',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-codec.ism/.mpd'
+  },
+  {
+    'title': 'Dash - Alternate audio language',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.mpd'
+  },
+  {
+    'title': 'Dash - Accessibility - audio description',
+    'src': 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-desc-aud.ism/.mpd'
+  },
+  {
+    'title': 'Dash - Pure live',
+    'src': 'https://demo.unified-streaming.com/k8s/live/stable/live.isml/.mpd'
+  },
+  {
+    'title': 'Dash - Timeshift (5 minutes)',
+    'src': 'https://demo.unified-streaming.com/k8s/live/stable/live.isml/.mpd?time_shift=300'
+  },
+  {
+    'title': 'Dash - DVB DASH low latency',
+    'src': 'https://demo.unified-streaming.com/k8s/live/stable/live-low-latency.isml/.mpd'
+  },
+  {
+    'title': 'Test1',
+    'description': 'Forced subtitles',
+    'src': 'https://prd.vod-srgssr.ch/origin/1053457/fr/master.m3u8?complexSubs=true'
+  }
+];

--- a/demo/src/ExamplesLoader.js
+++ b/demo/src/ExamplesLoader.js
@@ -1,0 +1,28 @@
+import { openModal } from './ExampleDialog';
+import { EXAMPLES } from './Examples';
+
+/**
+ * Loads a list of video examples into the specified HTML container and sets
+ * up a click event to open modals for each video.
+ */
+export const loadExamples = () => {
+  const examplesList = document.getElementById('examples');
+
+  EXAMPLES.forEach((example) => {
+    const exampleEl = document.createElement('a');
+
+    exampleEl.classList.add('btn-link', 'example-btn');
+    exampleEl.href = '#';
+    exampleEl.textContent = example.title;
+
+    examplesList.appendChild(exampleEl);
+  });
+
+  examplesList.addEventListener('click', (event) => {
+    const exampleIdx = Array
+      .from(event.target.parentNode.children)
+      .indexOf(event.target);
+
+    openModal(EXAMPLES[exampleIdx]);
+  });
+};

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,25 +1,17 @@
 import Pillarbox from '../../src/pillarbox.js';
 import '../../src/middleware/srgssr.js';
+import { loadExamples } from './ExamplesLoader';
+import { openModal } from './ExampleDialog';
 
-// Get pillarbox version
-document.querySelector('.version').textContent = Pillarbox.VERSION.pillarbox;
-
-// Initialize the player
+// Initialize the player statically
 const player = new Pillarbox('player', {
-  /** @see https://docs.videojs.com/html5#playsinline */
   playsinline: true,
-  /** @see https://videojs.com/guides/options/#liveui */
   liveui: true,
   muted: true,
   fill: true,
-  /** @see https://videojs.com/guides/options/#plugins */
-  plugins: {
-    eme: true,
-  },
+  plugins: { eme: true },
   html5: {
-    vhs : {
-      useForcedSubtitles: true
-    }
+    vhs: { useForcedSubtitles: true }
   }
 });
 
@@ -29,29 +21,20 @@ window.pillarbox = Pillarbox;
 // Expose the player in the window object
 window.player = player;
 
-// Source examples
-window.sourceExamples = {
-  bipbop: {
-    src: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8',
-    type: 'application/x-mpegURL',
-  },
-  appleAtmos : {
-    src: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8',
-    type: 'application/x-mpegURL',
-  },
-  urn: {
-    src: 'urn:rts:video:14160770',
-    type: 'srgssr/urn',
-  },
-  rts1: {
-    src: 'urn:rts:video:3608506',
-    type: 'srgssr/urn',
-  },
-  token: {
-    src: 'urn:rts:video:1967124',
-    type: 'srgssr/urn',
-  }
-};
+// Set Pillarbox version
+document.querySelector('.version').textContent = Pillarbox.VERSION.pillarbox;
 
-// Load the source
-player.src(window.sourceExamples.bipbop);
+// Allow to load any example
+document
+  .querySelector('#search-bar')
+  .addEventListener('keyup', (event) => {
+    if (event.key === 'Enter') {
+      const src = event.target.value;
+      const type = src.startsWith('urn:') ? 'srgssr/urn' : undefined;
+
+      openModal({ src, type });
+    }
+  });
+
+// Load examples from `Examples.js`
+loadExamples();


### PR DESCRIPTION
## Description

Resolves #51

A demo page with several functionalities :

* An input box allowing url and srg/ssr urn loading.
* A list of examples.
* Responsive design.
* Selected items are loaded into a modal with pillarbox-web.

## Changes made

Removed old demo page.

