### PR TITLE
chore(npm): github page destination folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
   "targets": {
     "github-page": {
       "publicUrl": "./",
-      "source": [
-        "demo/index.html"
-      ],
+      "source": "demo/index.html",
+      "distDir": "./dist",
       "isLibrary": false,
       "outputFormat": "esmodule"
     },


### PR DESCRIPTION
## Description

This avoids publishing the github page in the `github-page` subdirectory instead of the `root`.

## Changes made

- add `distDir` file for target `github-page`

