### PR TITLE
fix(srg-analytics): playhead position is not updated

### DIFF
--- a/src/analytics/SRGAnalytics.js
+++ b/src/analytics/SRGAnalytics.js
@@ -715,6 +715,7 @@ class SRGAnalytics {
       this.uptime();
     }
 
+    this.timeUpdate();
     this.notify('play');
 
     if (this.isSeeking) this.isSeeking = false;


### PR DESCRIPTION
## Description

Fixes #60 where `media_position` is not updated after resuming playback after `seeking` while the player was `paused`.

## Changes made

- ensure the time is up to date before calling `notify` play