### PR TITLE
feat(demo): add DRM support to demo page

### DIFF
--- a/demo/src/ExampleDialog.js
+++ b/demo/src/ExampleDialog.js
@@ -16,12 +16,13 @@ dialog.querySelector('#pbw-dialog-close-btn').addEventListener('click', () => di
  * @param {object} options - An object containing the source and type of the video to be played.
  * @param {string} options.src - The source URL of the video.
  * @param {string} [options.type] - (Optional) The type/format of the video (e.g., 'video/mp4').
+ * @param {object} [options.keySystems] - (Optional) The DRM configuration for DRM protected sources.
  */
-export const openModal = async ({ src, type }) => {
+export const openModal = async ({ src, type, keySystems }) => {
   const player = Pillarbox.getPlayer('player');
 
   if (player.currentSrc() !== src) {
-    player.src({ src, type });
+    player.src({ src, type, keySystems });
   }
 
   dialog.showModal();

--- a/demo/src/Examples.js
+++ b/demo/src/Examples.js
@@ -223,7 +223,9 @@ export const EXAMPLES = {
     {
       'title': 'VoD - Dash Widewine cenc (H264)',
       'src': 'https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd',
-      'licenseUrl': 'https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test'
+      'keySystems': {
+        'com.widevine.alpha': 'https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test'
+      }
     },
     {
       'title': 'VoD - Dash (H265)',
@@ -232,7 +234,9 @@ export const EXAMPLES = {
     {
       'title': 'VoD - Dash widewine cenc (H265)',
       'src': 'https://storage.googleapis.com/wvmedia/cenc/hevc/tears/tears.mpd',
-      'licenseUrl': 'https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test'
+      'keySystems': {
+        'com.widevine.alpha': 'https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test'
+      }
     },
     {
       'title': 'VoD - Dash - MP4',


### PR DESCRIPTION
## Description

Closes #64

## Changes made

Modified examples with license URLs to adhere to the expected video-js format of 'keySystems', specifying the vendor and URL as such :

```javascript
{
  'title': '...',
  'src': ' ...',
  'keySystems': {
    'com.widevine.alpha': '...'
  }
}
```

