### PR TITLE
fix(media-composition): missing block reason property

### DIFF
--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -186,6 +186,7 @@ class MediaComposition {
       analyticsMetadata: this.getMergedAnalyticsMetadata(
         resource.analyticsMetadata
       ),
+      blockReason: this.getMainChapter().blockReason,
       vendor: this.getMainChapter().vendor,
       drmList: resource.drmList,
       dvr: resource.dvr,


### PR DESCRIPTION
## Description

Even though the `blockReason` feature has been implemented. It seems that the `blockReason` property has been forgotten, resulting in blocking reasons appearing as simple error messages.

## Changes made

- adds the `blockReason` property to the `getMainResources` function

