### PR TITLE
chore(demo): add live tracker configuration

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,14 +5,18 @@ import { openModal } from './ExampleDialog';
 
 // Initialize the player statically
 const player = new Pillarbox('player', {
-  playsinline: true,
+  fill: true,
+  html5: {
+    vhs: { useForcedSubtitles: true },
+  },
+  liveTracker: {
+    trackingThreshold: 120,
+    liveTolerance: 15,
+  },
   liveui: true,
   muted: true,
-  fill: true,
+  playsinline: true,
   plugins: { eme: true },
-  html5: {
-    vhs: { useForcedSubtitles: true }
-  }
 });
 
 // Expose the Pillarbox in the window object


### PR DESCRIPTION


## Description

This configuration allows:

- set the threshold for displaying the the progress bar. This avoids displaying the
progress bar when a live stream has too short a
live window.
- set the tolerance at which the playback position is considered live.
## Changes made

- adds the `liveTracker` configuration

