### PR TITLE
chore(demo): add position sticky to category's title

### DIFF
--- a/demo/scss/examples.scss
+++ b/demo/scss/examples.scss
@@ -13,6 +13,14 @@
   width: 100%;
 }
 
+.category h2 {
+  position: sticky;
+  top: 0;
+  margin: 0;
+  padding: var(--size-3) 0;
+  background-color: var(--gray-11);
+}
+
 #examples .category p {
   margin-bottom: 0;
   color: var(--gray-5);


### PR DESCRIPTION
## Description

This allows the category title to remain at the top of the page when scrolling down.

## Changes made

- adds the same background color as the body
- removes the title margin
- adds padding at top and bottom

