### PR TITLE
chore(demo): close dialog element

### DIFF
--- a/demo/src/ExampleDialog.js
+++ b/demo/src/ExampleDialog.js
@@ -8,6 +8,13 @@ dialog.addEventListener('close', () => Pillarbox.getPlayer('player').pause());
 // Close the dialog on close button clicked
 dialog.querySelector('#pbw-dialog-close-btn').addEventListener('click', () => dialog.close());
 
+// Close the dialog when the backdrop is clicked
+dialog.addEventListener('click', (e) => {
+  if (dialog !== e.target) return;
+
+  dialog.close();
+});
+
 /**
  * Opens a modal containing a video player with specified source and type. Can only
  * load URN if the type 'srgssr/urn`is explicitly provided, otherwise the created


### PR DESCRIPTION
## Description

Allows to close the `dialog` by clicking on the backdrop.

## Changes made

- add a click event listener which will `close` the `dialog` element only if the `target` element is the `dialog` itself

