### PR TITLE
feat(demo): improve examples layout display

### DIFF
--- a/demo/scss/examples.scss
+++ b/demo/scss/examples.scss
@@ -18,6 +18,7 @@
 }
 
 .example-btn {
+  display: grid;
   margin: var(--size-1) 0;
   padding: var(--size-5) 0;
 }
@@ -36,4 +37,14 @@
 
 #load-bar {
   width: 90%;
+}
+
+.example-title {
+  margin-top: var(--size-2);
+  color: var(--gray-6);
+  font-style: italic;
+}
+
+.example-description {
+  padding-right: var(--size-1);
 }

--- a/demo/src/example/example-page.js
+++ b/demo/src/example/example-page.js
@@ -21,8 +21,16 @@ const createContentEl = () => parseHtml(`
       <div class="category" data-category="${category}">
         <h2>${category}</h2>
         ${examples.map(example => `
-          ${example.description != null ? `<p>${example.description}</p>` : ''}
-          <button class="example-btn">${example.title}</button>
+        <button class="btn example-btn">
+          ${
+            example.description != null
+            ? `
+              <span class="example-description">${example.description}</span>
+              <span class="example-title">${example.title}</span>
+              `
+            : `${example.title}`
+          }
+        </button>
         `).join('')}
       </div>
       `).join('')}


### PR DESCRIPTION
## Description

This pull request allows us to enhance the presentation of examples, which include a title and a description.

> A picture is worth a thousand words

| Current display | Improved display |
| --------- | --------- | 
| ![current](https://github.com/SRGSSR/pillarbox-web/assets/3347810/8e4c5f0f-aaa5-44e7-8538-563363812e2f) | ![improved](https://github.com/SRGSSR/pillarbox-web/assets/3347810/e57ca8d8-fb16-4260-b1d6-be45b8a71977) | 

## Changes made

- A CSS class `example-title` has been added to manage the style of an example title.
- A CSS class `example-description` has been added to manage the style of an example description.
- The example cell has been updated when it contains both a title and a description.