### PR TITLE
feat(demo): add spinner component

### DIFF
--- a/demo/scss/index.scss
+++ b/demo/scss/index.scss
@@ -85,5 +85,5 @@ dialog::backdrop {
 @import "header";
 @import "search";
 @import "content-tree";
-
+@import "spinner";
 

--- a/demo/scss/spinner.scss
+++ b/demo/scss/spinner.scss
@@ -1,0 +1,26 @@
+.slide-fade {
+  opacity: 0;
+  animation: var(--animation-fade-in) forwards, var(--animation-slide-in-up) backwards;
+  animation-duration: 0.4s;
+  animation-timing-function: var(--ease-elastic-in-3);
+}
+
+.spinner {
+  display: block;
+  width: var(--size-7);
+  height: var(--size-7);
+  border: 3px solid var(--gray-2);
+  border-bottom-color: transparent;
+  border-radius: var(--radius-round);
+  animation: var(--animation-spin);
+}
+
+.spinner-container {
+  display: grid;
+  place-content: center;
+  margin: var(--size-10);
+}
+
+.hidden {
+  display: none;
+}

--- a/demo/src/content-lists/content-tree-page.js
+++ b/demo/src/content-lists/content-tree-page.js
@@ -8,19 +8,7 @@ import { parseHtml } from '../core/html-utils';
 import router from '../core/router';
 import { openPlayerModal } from '../player/player-dialog';
 import { contentTreeRootSections } from './content-tree-root-sections';
-
-/**
- * Creates the main content elements for this page : the navigation container and the
- * sections container.
- *
- * @returns {HTMLElement} The created content element.
- */
-const createContentEl = () => {
-  return parseHtml(`
-    <div id="tree-navigation"></div>
-    <div id="sections"></div>
-  `);
-};
+import SpinnerComponent from '../core/spinner-component';
 
 /**
  * Represents the Lists page.
@@ -29,27 +17,49 @@ const createContentEl = () => {
  */
 class ListsPage {
   /**
+   * The spinner component of this page.
+   *
+   * @private
+   * @type {SpinnerComponent}
+   */
+  #spinner;
+  /**
+   * Stack to keep track of the traversal steps for navigation.
+   *
+   * @private
+   * @type {Array<Array<Section>>}
+   */
+  #traversalStack = [];
+  /**
+   * The DOM element that contains the sections.
+   *
+   * @private
+   * @type {Element}
+   */
+  #sectionsEl;
+  /**
+   * The DOM element that contains the navigation.
+   *
+   * @private
+   * @type {Element}
+   */
+  #treeNavigationEl;
+  /**
+   * The current level of the content tree.
+   *
+   * @private
+   * @type {Array<Section>}
+   */
+  #currentLevel;
+
+  /**
    * Creates an instance of ListsPage.
    *
    * @constructor
    * @param {Array} contentRoot - The root of the content tree.
    */
   constructor(contentRoot) {
-    /**
-     * The current level of the content tree.
-     * @type {Array}
-     */
-    this.currentLevel = contentRoot;
-    /**
-     * Stack to keep track of the traversal steps for navigation.
-     * @type {Array}
-     */
-    this.traversalStack = [];
-    /**
-     * Flag indicating whether content is currently being loaded.
-     * @type {boolean}
-     */
-    this.loading = false;
+    this.#currentLevel = contentRoot;
   }
 
   /**
@@ -57,36 +67,52 @@ class ListsPage {
    */
   init() {
     // Create the view
-    document.querySelector('.container').replaceChildren(...createContentEl());
-    this.updateView(this.currentLevel);
+    const containerEl = document.querySelector('.container');
 
+    containerEl.replaceChildren(...parseHtml(`
+        <div id="tree-navigation"></div>
+        <div id="sections"></div>
+    `));
+
+    this.#spinner = new SpinnerComponent(containerEl);
+    this.#sectionsEl = document.querySelector('#sections');
+    this.#treeNavigationEl = document.querySelector('#tree-navigation');
+
+    this.updateView(this.#currentLevel);
+    this.initListeners();
+  }
+
+  /**
+   * Initializes the DOM event listeners.
+   */
+  initListeners() {
     // Attach content selection listener
-    document.querySelector('#sections').addEventListener('click', async (event) => {
-      if (this.loading || event.target.tagName.toLowerCase() !== 'button') {
+    this.#sectionsEl.addEventListener('click', async (event) => {
+      if (!this.#spinner.hidden || event.target.tagName.toLowerCase() !== 'button') {
         return;
       }
 
-      this.loading = true;
+      this.#spinner.show();
       const sectionIndex = event.target.parentNode.dataset.sectionIdx;
       const nodeIndex = event.target.dataset.nodeIdx;
 
       try {
         await this.navigateTo(sectionIndex, nodeIndex);
       } finally {
-        this.loading = false;
+        this.#spinner.hide();
       }
     });
 
     // Attach navigation listener
-    document.querySelector('#tree-navigation').addEventListener('click', (event) => {
+    this.#treeNavigationEl.addEventListener('click', (event) => {
       if (event.target.tagName.toLowerCase() !== 'button') {
         return;
       }
 
       const navigationIdx = event.target.dataset.navigationIdx;
 
-      this.currentLevel = this.traversalStack[navigationIdx].level;
-      this.traversalStack.splice(navigationIdx);
+      this.#currentLevel = this.#traversalStack[navigationIdx].level;
+      this.#traversalStack.splice(navigationIdx);
       this.updateView();
     });
   }
@@ -98,20 +124,21 @@ class ListsPage {
    * @param {number} nodeIndex - The index of the node.
    */
   async navigateTo(sectionIndex, nodeIndex) {
-    const selectedSection = this.currentLevel[sectionIndex];
+    const selectedSection = this.#currentLevel[sectionIndex];
     const selectedNode = selectedSection.nodes[nodeIndex];
 
     if (selectedSection.isLeaf()) {
       openPlayerModal({ src: selectedNode.urn, type: 'srgssr/urn' });
     } else {
+      this.#sectionsEl.replaceChildren();
       const nextLevel = [await selectedSection.resolve(selectedNode)];
 
-      this.traversalStack.push({
-        level: this.currentLevel,
+      this.#traversalStack.push({
+        level: this.#currentLevel,
         sectionIndex,
         nodeIndex
       });
-      this.currentLevel = nextLevel;
+      this.#currentLevel = nextLevel;
       this.updateView();
     }
   }
@@ -128,8 +155,8 @@ class ListsPage {
    * Updates the sections in the content tree page.
    */
   updateSections() {
-    document.querySelector('#sections').replaceChildren(
-      ...parseHtml(this.currentLevel.map((section, idx) => `
+    this.#sectionsEl.replaceChildren(
+      ...parseHtml(this.#currentLevel.map((section, idx) => `
       <div data-section-idx="${idx}" class="section">
           <h2>${section.title}</h2>
           ${section.nodes.map((node, idx) => `
@@ -144,20 +171,19 @@ class ListsPage {
    * Updates the navigation in the content tree page.
    */
   updateNavigation() {
-    if (this.traversalStack.length > 0) {
-      document.querySelector('#tree-navigation').replaceChildren(...parseHtml(`
+    if (this.#traversalStack.length > 0) {
+      this.#treeNavigationEl.replaceChildren(...parseHtml(`
       <button data-navigation-idx="0">Home</button>
-      ${this.traversalStack.slice(1).map((step, idx) => `
-      &gt;  <button data-navigation-idx="${idx + 1}">${step.level[step.sectionIndex].title}</button>
+      ${this.#traversalStack.slice(1).map((step, idx) => `
+      <span>&gt;</span>
+      <button data-navigation-idx="${idx + 1}">${step.level[step.sectionIndex].title}</button>
       `).join('')}
     `));
     } else {
-      document.querySelector('#tree-navigation').replaceChildren();
+      this.#treeNavigationEl.replaceChildren();
     }
   }
 }
 
 // Add route for 'content-tree' path
-router.addRoute('lists', () => {
-  new ListsPage(contentTreeRootSections).init();
-});
+router.addRoute('lists', () => new ListsPage(contentTreeRootSections).init());

--- a/demo/src/core/il-provider.js
+++ b/demo/src/core/il-provider.js
@@ -35,16 +35,18 @@ class ILProvider {
    *
    * @param {string} bu - The business unit for which the search is performed (rsi, rtr, rts, srf or swi).
    * @param {string} query - The search query.
+   * @param {AbortSignal} [signal=undefined] - (Optional) An abort signal, allows to abort the query through an abort controller.
    *
    * @returns {Promise<Array<{ title: string, urn: string }>>} - A promise that resolves to an array
    * of objects containing the title and URN of the search results.
    *
    * @throws {Promise<Response>} - A rejected promise with the response object if the fetch request fails.
    */
-  async search(bu, query) {
+  async search(bu, query, signal = undefined) {
     const data = await this.fetch(
       `/${bu.toLowerCase()}/searchResultMediaList`,
-      { ...DEFAULT_SEARCH_PARAMS, 'q': query }
+      { ...DEFAULT_SEARCH_PARAMS, 'q': query },
+      signal
     );
 
     return data.searchResultMediaList.map(
@@ -261,11 +263,11 @@ class ILProvider {
     );
   }
 
-  async fetch(path, params = DEFAULT_QUERY_PARAMS) {
+  async fetch(path, params = DEFAULT_QUERY_PARAMS, signal = undefined) {
     const queryParams = new URLSearchParams(params).toString();
     const url = `https://${this.baseUrl}/${path.replace(/^\/+/, '')}?${queryParams}`;
 
-    return fetch(url).then(response => {
+    return fetch(url, { signal }).then(response => {
       if (!response.ok) {
         return Promise.reject(response);
       }

--- a/demo/src/core/spinner-component.js
+++ b/demo/src/core/spinner-component.js
@@ -1,0 +1,81 @@
+import { parseHtml } from './html-utils';
+
+let SPINNER_ID = 0;
+
+/**
+ * A simple spinner component that can be attached to a DOM element.
+ * @class
+ */
+class SpinnerComponent {
+  /**
+   * A private property to track the visibility state of the spinner.
+   *
+   * @private
+   * @member {boolean}
+   */
+  #hidden = true;
+  /**
+   * The spinner element reference.
+   *
+   * @private
+   * @type {Element}
+   */
+  #spinnerEl;
+
+  /**
+   * Creates a new Spinner component and attaches it to the provided parent element.
+   *
+   * @constructor
+   * @param {Element} parentEl - The target DOM element where the new spinner will be attached
+   */
+  constructor(parentEl) {
+    const id = `spinner-${SPINNER_ID += 1}`;
+
+    parentEl.appendChild(parseHtml(`
+      <div id="${id}" class="spinner-container hidden">
+        <div class="spinner"></div>
+      </div>
+    `)[0]);
+
+    this.#spinnerEl = document.getElementById(id);
+
+    this.#spinnerEl.addEventListener('animationend', (event) => {
+      event.target.classList.remove('slide-fade');
+    });
+  }
+
+  /**
+   * Show the spinner.
+   */
+  show() {
+    if (this.hidden) {
+      this.#spinnerEl.classList.remove('hidden');
+      this.#spinnerEl.classList.add('slide-fade');
+      this.#hidden = false;
+    }
+  }
+
+  /**
+   * Hide the spinner.
+   */
+  hide() {
+    if (!this.hidden) {
+      this.#spinnerEl.classList.add('hidden');
+      this.#spinnerEl.classList.remove('slide-fade');
+
+      this.#hidden = true;
+    }
+  }
+
+  /**
+   * Get the visibility state of the spinner.
+   *
+   * @readonly
+   * @member {boolean}
+   */
+  get hidden() {
+    return this.#hidden;
+  }
+}
+
+export default SpinnerComponent;

--- a/demo/src/search/search-page.js
+++ b/demo/src/search/search-page.js
@@ -8,9 +8,119 @@ import router from '../core/router';
 import { parseHtml } from '../core/html-utils';
 import { openPlayerModal } from '../player/player-dialog';
 import ilProvider from '../core/il-provider';
+import SpinnerComponent from '../core/spinner-component';
 
-const createContentEl = () => {
-  return parseHtml(`
+/**
+ * Represents the search page.
+ *
+ * @class
+ */
+class SearchPage {
+  /**
+   * The spinner component for displaying loading state.
+   *
+   * @private
+   * @type {SpinnerComponent}
+   */
+  #spinner;
+
+  /**
+   * The element to display search results.
+   *
+   * @private
+   * @type {Element}
+   */
+  #resultsEl;
+
+  /**
+   * The dropdown element for selecting a business unit.
+   *
+   * @private
+   * @type {Element}
+   */
+  #dropdownEl;
+
+  /**
+   * The abort controller for handling search cancellation.
+   *
+   * @private
+   * @type {AbortController}
+   */
+  #abortController;
+
+  /**
+   * Creates an instance of SearchPage.
+   * Initializes and sets up the necessary elements and event listeners.
+   */
+  constructor() {
+    const containerEl = document.querySelector('.container');
+
+    containerEl.replaceChildren(...this.createContentEl());
+    this.#spinner = new SpinnerComponent(containerEl);
+    this.#resultsEl = document.querySelector('#results');
+    this.#dropdownEl = document.querySelector('#bu-dropdown');
+    this.#abortController = new AbortController();
+    this.initListeners();
+  }
+
+  /**
+   * Initializes the event listeners for the search bar and search results :
+   *
+   * - Listens for 'Enter' key press to trigger a search.
+   * - Listens for clicks on search results to open the player modal.
+   */
+  initListeners() {
+    document.querySelector('#search-bar').addEventListener('keyup', async (event) => {
+      if (event.key === 'Enter') {
+        const bu = this.#dropdownEl.value;
+
+        await this.search(bu, event.target.value);
+      }
+    });
+
+    this.#resultsEl.addEventListener('click', (event) => {
+      if (event.target.tagName.toLowerCase() !== 'button') {
+        return;
+      }
+
+      openPlayerModal({ src: event.target.dataset.urn, type: 'srgssr/urn' });
+    });
+  }
+
+  /**
+   * Performs a search based on the specified business unit and query. Performing
+   * a new search will abort the previous search if it's ongoing and display a
+   * loading spinner for the asynchronous operation.
+   *
+   * @param {string} bu - The selected business unit.
+   * @param {string} query - The search query.
+   */
+  async search(bu, query) {
+    // Abort previous search and creates a new abort controller
+    this.#abortController?.abort('New search launched');
+    this.#abortController = new AbortController();
+
+    const signal = this.#abortController.signal;
+
+    this.#resultsEl.replaceChildren();
+    this.#spinner.show();
+
+    try {
+      const results = await ilProvider.search(bu, query, signal);
+
+      this.#resultsEl.replaceChildren(...this.createResultsEl(results));
+    } finally {
+      this.#spinner.hide();
+    }
+  }
+
+  /**
+   * Creates and returns the HTML elements for the search page content.
+   *
+   * @returns {HTMLElement[]} - An array of HTML elements representing the search page content.
+   */
+  createContentEl() {
+    return parseHtml(`
     <div class="search-bar-container">
       <select id="bu-dropdown" aria-label="Select a business unit">
           <option value="rsi" selected>RSI</option>
@@ -25,32 +135,21 @@ const createContentEl = () => {
     <!-- Search results -->
     <div id="results"></div>
   `);
-};
+  }
 
-const createResultsEl = (results) => {
-  return parseHtml(results.map(
-    r => `<button class="result-btn" data-urn="${r.urn}">${r.title}</button>`
-  ).join(''));
-};
+  /**
+   * Creates and returns HTML elements for the search results based on the provided results data.
+   *
+   * @param {Object[]} results - An array of search results.
+   *
+   * @returns {HTMLElement[]} - An array of HTML elements representing the search results.
+   */
+  createResultsEl(results) {
+    return parseHtml(results.map(
+      r => `<button class="result-btn" data-urn="${r.urn}">${r.title}</button>`
+    ).join(''));
+  }
+}
 
-router.addRoute('search', () => {
-  document.querySelector('.container').replaceChildren(...createContentEl());
-  document.querySelector('#search-bar').addEventListener('keyup', (event) => {
-    if (event.key === 'Enter') {
-      const bu = document.querySelector('#bu-dropdown').value;
-      const query = event.target.value;
 
-      ilProvider.search(bu, query).then(results => {
-        document.querySelector('#results').replaceChildren(...createResultsEl(results));
-      });
-    }
-  });
-
-  document.querySelector('#results').addEventListener('click', (event) => {
-    if (event.target.tagName.toLowerCase() !== 'button') {
-      return;
-    }
-
-    openPlayerModal({ src: event.target.dataset.urn, type: 'srgssr/urn' });
-  });
-});
+router.addRoute('search', () => new SearchPage());


### PR DESCRIPTION
## Description

Closes #82

Introduces a `SpinnerComponent` that can be dynamically attached to a DOM element and can be shown or hide on command.

This spinner offers a visual cue to signify that content is being loaded or processed during user interactions or asynchronous operations. It has been added to the following pages :

- **Search** : The spinner is shown whenever a search is launched.
- **Lists**: The spinner is shown when a section is opened.

## Changes

- The search page is now a class.
- Performing a new search will abort the previous request if it's ongoing.

