### PR TITLE
chore(demo): expose videojs in window object

### DIFF
--- a/demo/src/player/player.js
+++ b/demo/src/player/player.js
@@ -24,3 +24,13 @@ const player = new Pillarbox('player', {
 // Expose Pillarbox and player in the window object for debugging
 window.pillarbox = Pillarbox;
 window.player = player;
+
+// TODO must be remove once tagCommander is pillarbox ready
+//
+// Allows to track comscore events
+//
+// This is necessary because a tagCommander script uses videojs directly for some
+// unknown reason. Pillarbox does not expose videojs, because pillarbox
+// is a superset of videojs, this causes an error preventing comscore
+// from initializing correctly.
+window.videojs = Pillarbox;


### PR DESCRIPTION
## Description

Temporarily exposes `videojs` in the object `window` to allow Comscore to initialize correctly.

## Changes made

- add a global variable named `videojs` extending `pillarbox`
