### PR TITLE
feat(demo): add content pagination

### DIFF
--- a/demo/scss/index.scss
+++ b/demo/scss/index.scss
@@ -199,12 +199,12 @@ dialog::backdrop {
   color: var(--red-7);
 }
 
-
 @import "dialog";
 @import "examples";
 @import "header";
 @import "search";
 @import "content-tree";
 @import "spinner";
+@import "sentinel";
 @import "animations";
 

--- a/demo/scss/search.scss
+++ b/demo/scss/search.scss
@@ -17,6 +17,7 @@
 .results-container {
   display: flex;
   flex-direction: column;
+  margin-top: var(--size-3);
 }
 
 .results-container:empty {

--- a/demo/scss/sentinel.scss
+++ b/demo/scss/sentinel.scss
@@ -1,0 +1,9 @@
+.sentinel {
+  width: 100%;
+  height: var(--size-9);
+  margin-top: var(--size-4);
+  background-color: var(--color-9);
+  border: 1px solid var(--color-10);
+  border-radius: var(--radius-3);
+  animation: var(--animation-blink);
+}

--- a/demo/src/core/html-utils.js
+++ b/demo/src/core/html-utils.js
@@ -9,3 +9,17 @@ export const parseHtml = (htmlString) => {
 
   return el.body.childNodes;
 };
+
+const DEFAULT_INT_OPTIONS = { root: null, rootMargin: '0px', threshold: 0.1 };
+
+export const onIntersecting =
+  (target, callback, options = DEFAULT_INT_OPTIONS) => {
+    new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          callback();
+          // observer.unobserve(entry.target);
+        }
+      });
+    }, options).observe(target);
+  };

--- a/demo/src/core/sentinel-component.js
+++ b/demo/src/core/sentinel-component.js
@@ -1,0 +1,44 @@
+import { onIntersecting, parseHtml } from './html-utils';
+
+let SENTINEL_ID = 0;
+
+/**
+ * A simple sentinel component that can be attached to a DOM element.
+ * @class
+ */
+class SentinelComponent {
+  /**
+   * The sentinel element reference.
+   *
+   * @private
+   * @type {Element}
+   */
+  #el;
+
+  /**
+   * Creates a new Sentinel component and attaches it to the DOM through the
+   * provided attach method.
+   *
+   * @constructor
+   * @param {(node?: Node) => void} attach - Callback function to customize
+   *     how the sentinel is attached to document. Receives the sentinel
+   *     HTML node as an argument.
+   * @param {function} intersectCallback - This function is called when the sentinel
+   *     element is intersecting the viewport.
+   */
+  constructor(attach, intersectCallback) {
+    const id = `sentinel-${SENTINEL_ID += 1}`;
+
+    attach(parseHtml(`<div id="${id}" class="sentinel"></div>`)[0]);
+
+    this.#el = document.getElementById(id);
+
+    onIntersecting(this.#el, intersectCallback);
+  }
+
+  remove() {
+    this.#el.remove();
+  }
+}
+
+export default SentinelComponent;

--- a/demo/src/core/spinner-component.js
+++ b/demo/src/core/spinner-component.js
@@ -20,28 +20,36 @@ class SpinnerComponent {
    * @private
    * @type {Element}
    */
-  #spinnerEl;
+  #el;
 
   /**
    * Creates a new Spinner component and attaches it to the provided parent element.
+   * The spinner start hidden unless specified otherwise,
    *
    * @constructor
-   * @param {Element} parentEl - The target DOM element where the new spinner will be attached
+   * @param {(node?: Node) => void} attach - Callback function
+   *     to customize how the spinner is attached to document. Receives the spinner
+   *     HTML node as an argument.
+   * @param {boolean} [hidden=true] - Whether the spinner starts hidden or not.
    */
-  constructor(parentEl) {
+  constructor(attach, hidden = true) {
     const id = `spinner-${SPINNER_ID += 1}`;
 
-    parentEl.appendChild(parseHtml(`
+    attach(parseHtml(`
       <div id="${id}" class="spinner-container hidden">
         <div class="spinner"></div>
       </div>
     `)[0]);
 
-    this.#spinnerEl = document.getElementById(id);
+    this.#el = document.getElementById(id);
 
-    this.#spinnerEl.addEventListener('animationend', (event) => {
+    this.#el.addEventListener('animationend', (event) => {
       event.target.classList.remove('slide-up-fade-in');
     });
+
+    if (!hidden) {
+      this.show();
+    }
   }
 
   /**
@@ -50,8 +58,8 @@ class SpinnerComponent {
    * @param {boolean} show - if the spinner will be shown or hidden.
    */
   toggle(show) {
-    this.#spinnerEl.classList.toggle('hidden', !show);
-    this.#spinnerEl.classList.toggle('slide-up-fade-in', show);
+    this.#el.classList.toggle('hidden', !show);
+    this.#el.classList.toggle('slide-up-fade-in', show);
     this.#hidden = !show;
   }
 
@@ -77,6 +85,10 @@ class SpinnerComponent {
    */
   get hidden() {
     return this.#hidden;
+  }
+
+  remove() {
+    this.#el.remove();
   }
 }
 

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -7,7 +7,7 @@ import './player/player';
 import './header/header-component';
 import './example/example-page';
 import './search/search-page';
-import './content-lists/content-tree-page';
+import './lists/lists-page';
 import router from './core/router';
 
 // Initialize the router with the current path or 'examples' if none is found

--- a/demo/src/lists/lists-page.js
+++ b/demo/src/lists/lists-page.js
@@ -7,7 +7,7 @@
 import { parseHtml } from '../core/html-utils';
 import router from '../core/router';
 import { openPlayerModal } from '../player/player-dialog';
-import { contentTreeRootSections } from './content-tree-root-sections';
+import { listsSections } from './lists-sections';
 import SpinnerComponent from '../core/spinner-component';
 import Pillarbox from '../../../src/pillarbox';
 
@@ -75,7 +75,9 @@ class ListsPage {
         <div id="sections"></div>
     `));
 
-    this.#spinner = new SpinnerComponent(containerEl);
+    this.#spinner = new SpinnerComponent(
+      (node) => containerEl.appendChild(node)
+    );
     this.#sectionsEl = document.querySelector('#sections');
     this.#treeNavigationEl = document.querySelector('#tree-navigation');
 
@@ -204,4 +206,4 @@ class ListsPage {
 }
 
 // Add route for 'content-tree' path
-router.addRoute('lists', () => new ListsPage(contentTreeRootSections).init());
+router.addRoute('lists', () => new ListsPage(listsSections).init());

--- a/demo/src/lists/lists-sections.js
+++ b/demo/src/lists/lists-sections.js
@@ -41,7 +41,7 @@ class Section {
  *
  * @type {Section[]}
  */
-export const contentTreeRootSections = [
+export const listsSections = [
   new Section({
     title: 'TV Topics',
     nodes: ['RSI', 'RTR', 'RTS', 'SRF', 'SWI'],


### PR DESCRIPTION
## Description

Added pagination by providing continuous loading of results without the need for explicit actions:

- Introduced a new `SentinelComponent` that utilizes the Intersection Observer API to trigger the loading of the next page of search results when it comes into view.
- The `SearchPage` integrates the new `SentinelComponent` and adds  a `nextPage` method to fetch and display the next set of search results.

## Changes made

Renamed the following file:

- `content-tree-page.js` to `lists-page.js`.
- `content-tree-root-sections.js` to `lists-sections.js`.

