### PR TITLE
fix(data-provider): onlyChapters parameter default value

### DIFF
--- a/src/dataProvider/services/DataProvider.js
+++ b/src/dataProvider/services/DataProvider.js
@@ -16,11 +16,11 @@ class DataProvider {
    * Get media composition by URN.
    *
    * @param {String} urn urn:rts:video:9800629
-   * @param {Boolean} onlyChapters
+   * @param {Boolean} [onlyChapters=true] Whether to retrieve only chapters or not.
    *
    * @returns {Object} media composition json object
    */
-  getMediaCompositionByUrn(urn, onlyChapters = false) {
+  getMediaCompositionByUrn(urn, onlyChapters = true) {
     const url = `https://${this.baseUrl}mediaComposition/byUrn/${urn}?onlyChapters=${onlyChapters}&vector=portalplay`;
 
     return fetch(url)


### PR DESCRIPTION
## Description

When a chapter's URN is loaded, the entire media is played instead of just the requested chapter.

This fix allows a chapter to be played outside the context of the media it belongs to.

Additionally, setting the `onlyChapters` parameter to `true` ensures compliance with the initial decision and follows the same behavior as Pillarbox Android and iOS.

## Changes made

- change the default value of the `onlyChapters` parameter
- update the `jsdoc` associated with the parameter

