### PR TITLE
fix(demo): add 404 page in github page target

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "targets": {
     "github-page": {
       "publicUrl": "./",
-      "source": "demo/index.html",
+      "source": [
+        "demo/index.html",
+        "demo/404.html"
+      ],
       "distDir": "./dist",
       "isLibrary": false,
       "outputFormat": "esmodule"


### PR DESCRIPTION
## Changes made

- Added 'demo/404.html' to the github pages sources.

