### PR TITLE
chore(demo): reset player state before loading new media

### DIFF
--- a/demo/src/player/player-dialog.js
+++ b/demo/src/player/player-dialog.js
@@ -41,6 +41,13 @@ export const openPlayerModal = ({ src, type, keySystems }) => {
   const player = Pillarbox.getPlayer('player');
 
   if (player.currentSrc() !== src) {
+    player.reset();
+
+    // TODO should be removed when https://github.com/videojs/video.js/pull/8481
+    // and https://github.com/videojs/video.js/pull/8482 are released
+    player.error(null);
+    player.titleBar.update({ title: undefined, description: undefined });
+
     player.src({ src, type, keySystems });
   }
 


### PR DESCRIPTION
## Description

Ensures that the player has been reset before loading new media. This prevents the old media being displayed for a fraction of the time before the new media is loaded. It also allows media without a poster to inherit the poster from the previous media.

[Screencast from 30. 11. 23 16:29:58.webm](https://github.com/SRGSSR/pillarbox-web/assets/34163393/0e87bc5e-38dc-4ed3-b39d-02f074170b38)


## Changes made

- reset player
- reset error screen
- reset title bar

