### PR TITLE
chore(demo): remove temporary code resetting the player's UI

### DIFF
--- a/demo/src/player/player-dialog.js
+++ b/demo/src/player/player-dialog.js
@@ -42,12 +42,6 @@ export const openPlayerModal = ({ src, type, keySystems }) => {
 
   if (player.currentSrc() !== src) {
     player.reset();
-
-    // TODO should be removed when https://github.com/videojs/video.js/pull/8481
-    // and https://github.com/videojs/video.js/pull/8482 are released
-    player.error(null);
-    player.titleBar.update({ title: undefined, description: undefined });
-
     player.src({ src, type, keySystems });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
-        "video.js": "^8.6.1",
+        "video.js": "^8.7.0",
         "videojs-contrib-eme": "^3.11.1"
       },
       "devDependencies": {
@@ -7152,9 +7152,9 @@
       "dev": true
     },
     "node_modules/@videojs/http-streaming": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.7.0.tgz",
-      "integrity": "sha512-5uLFKBL8CvD56dxxJyuxqB5CY0tdoa4SE9KbXakeiAy6iFBUEPvTr2YGLKEWvQ8Lojs1wl+FQndLdv+GO7t9Fw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.8.0.tgz",
+      "integrity": "sha512-sZ5xM6XQdAPSxXKm767J28OLCJKY5mMxu7LVAqlyEJommECylm5D/RtzqAyIWM6u4V85qsJR4Zn9k6yzAhEDOw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",
@@ -7162,7 +7162,7 @@
         "global": "^4.4.0",
         "m3u8-parser": "^7.1.0",
         "mpd-parser": "^1.2.2",
-        "mux.js": "7.0.1",
+        "mux.js": "7.0.2",
         "video.js": "^7 || ^8"
       },
       "engines": {
@@ -7171,46 +7171,6 @@
       },
       "peerDependencies": {
         "video.js": "^7 || ^8"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/m3u8-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.1.0.tgz",
-      "integrity": "sha512-7N+pk79EH4oLKPEYdgRXgAsKDyA/VCo0qCHlUwacttQA0WqsjZQYmNfywMvjlY9MpEBVZEt0jKFd73Kv15EBYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
-        "global": "^4.4.0"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/m3u8-parser/node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/mux.js": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.1.tgz",
-      "integrity": "sha512-Omz79uHqYpMP1V80JlvEdCiOW1hiw4mBvDh9gaZEpxvB+7WYb2soZSzfuSRrK2Kh9Pm6eugQNrIpY/Bnyhk4hw==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "global": "^4.4.0"
-      },
-      "bin": {
-        "muxjs-transmux": "bin/transmux.js"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
       }
     },
     "node_modules/@videojs/vhs-utils": {
@@ -14355,9 +14315,9 @@
       }
     },
     "node_modules/m3u8-parser": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-6.2.0.tgz",
-      "integrity": "sha512-qlC00JTxYOxawcqg+RB8jbyNwL3foY/nCY61kyWP+RCuJE9APLeqB/nSlTjb4Mg0yRmyERgjswpdQxMvkeoDrg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.1.0.tgz",
+      "integrity": "sha512-7N+pk79EH4oLKPEYdgRXgAsKDyA/VCo0qCHlUwacttQA0WqsjZQYmNfywMvjlY9MpEBVZEt0jKFd73Kv15EBYQ==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.5",
@@ -23282,19 +23242,19 @@
       }
     },
     "node_modules/video.js": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.6.1.tgz",
-      "integrity": "sha512-CNYVJ5WWIZ7bOhbkkfcKqLGoc6WsE3Ft2RfS1lXdQTWk8UiSsPW2Ssk2JzPCA8qnIlUG9os/faCFsYWjyu4JcA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.7.0.tgz",
+      "integrity": "sha512-QAYQKsqyO/jxDed1AYdD4cEYQIuxGuqzMmfyyL3ZTgbCjo+f/XF+1Hw9aC1SZN6Wx3qDVLWKF7oB22uWST0N9w==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "3.7.0",
+        "@videojs/http-streaming": "3.8.0",
         "@videojs/vhs-utils": "^4.0.0",
         "@videojs/xhr": "2.6.0",
         "aes-decrypter": "^4.0.1",
         "global": "4.4.0",
         "keycode": "2.2.0",
-        "m3u8-parser": "^6.0.0",
-        "mpd-parser": "^1.0.1",
+        "m3u8-parser": "^7.1.0",
+        "mpd-parser": "^1.2.2",
         "mux.js": "^7.0.1",
         "safe-json-parse": "4.0.0",
         "videojs-contrib-quality-levels": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "stylelint-order": "^6.0.3"
   },
   "dependencies": {
-    "video.js": "^8.6.1",
+    "video.js": "^8.7.0",
     "videojs-contrib-eme": "^3.11.1"
   }
 }


### PR DESCRIPTION
## Description

Removes the temporary code that resets the player's UI between two source loads. This was made possible with the release of
[video.js@8.7.0](https://github.com/videojs/video.js/releases/tag/v8.7.0).

## Changes made

- removes temporary code
- updates the video.js dependency

