### PR TITLE
feat(demo): lists page state management

### DIFF
--- a/demo/scss/content-tree.scss
+++ b/demo/scss/content-tree.scss
@@ -12,4 +12,8 @@
       color: inherit;
     }
   }
+
+  i {
+    font-size: var(--size-3);
+  }
 }

--- a/demo/src/core/string-utils.js
+++ b/demo/src/core/string-utils.js
@@ -1,0 +1,16 @@
+/**
+ * Converts a given string to kebab case, spaces are replaced with hyphens
+ * and all letters are converted to lowercase.
+ *
+ * @param {string} str - The input string to be converted to kebab case.
+ * @returns {string} - The input string converted to kebab case.
+ *
+ * @example
+ * const result = toKebabCase("Hello World");
+ * console.log(result); // Output: "hello-world"
+ *
+ * @example
+ * const result = toKebabCase("CamelCase Example");
+ * console.log(result); // Output: "camelcase-example"
+ */
+export const toKebabCase = (str) => str.replace(/\s+/g, '-').toLowerCase();

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -11,11 +11,4 @@ import './lists/lists-page';
 import router from './core/router';
 
 // Initialize the router with the current path or 'examples' if none is found
-router.initBase();
-router.fallback = 'examples';
-
-const url = new URL(window.location.href);
-const path = url.pathname;
-const queryParams = Object.fromEntries(url.searchParams.entries());
-
-router.handleRouteChange(path, queryParams);
+router.start({ defaultPath: 'examples' });

--- a/demo/src/lists/lists-page-state-manager.js
+++ b/demo/src/lists/lists-page-state-manager.js
@@ -1,0 +1,186 @@
+import { toKebabCase } from '../core/string-utils';
+
+/**
+ * Manages the state of a lists page, allowing navigation and retrieval of section data.
+ *
+ * @class
+ */
+class ListsPageStateManager {
+  /**
+   * Creates an instance of ListsPageStateManager.
+   *
+   * @constructor
+   * @param {Array<Section>} root - The root level of the lists page.
+   */
+  constructor(root) {
+    /**
+     * Stack to keep track of the traversal steps for navigation.
+     *
+     * @private
+     * @type {Array<{level: Array<Section>, sectionIndex: number, nodeIndex: number}>}
+     */
+    this.stack = [];
+    /**
+     * The current level of the content tree.
+     *
+     * @private
+     * @type {Array<Section>}
+     */
+    this.level = root;
+  }
+
+  /**
+   * Initializes the state manager with the provided section, business unit, and nodes.
+   *
+   * @async
+   * @param {string} section - The section to initialize.
+   * @param {string} bu - The business unit associated with the section.
+   * @param {string} nodes - A comma-separated string of nodes representing the initial state.
+   * @returns {Promise<void>} - A promise that resolves when initialization is complete.
+   *
+   * @example
+   * // Example Usage:
+   * await stateManager.initialize("radio-shows", "rts", "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da,urn:rts:show:radio:9801398");
+   */
+  async initialize(section, bu, nodes) {
+    if (!section || !bu) {
+      return;
+    }
+
+    const sectionIndex = this.#findSectionIndex(section);
+    const nodeIndex = this.#findNodeIndex(this.level[sectionIndex].nodes, bu);
+
+    await this.fetchNextState(sectionIndex, nodeIndex);
+
+
+    for (const nodeStr of (nodes?.split(',') || [])) {
+      const nodeIndex = this.#findNodeIndex(this.level[0].nodes, nodeStr);
+
+      await this.fetchNextState(0, nodeIndex);
+    }
+  }
+
+  /**
+   * Fetches the next state based on the provided section index and node index.
+   *
+   * @param {number} sectionIndex - The index of the section.
+   * @param {number} nodeIndex - The index of the node.
+   * @returns {Promise<void>} - A promise that resolves when the state is fetched.
+   */
+  async fetchNextState(sectionIndex, nodeIndex) {
+    const section = this.level[sectionIndex];
+
+    this.stack.push({ level: this.level, sectionIndex, nodeIndex });
+    this.level = [await section.resolve(section.nodes[nodeIndex])];
+  }
+
+  /**
+   * Fetches the previous state based on the provided stack index.
+   *
+   * @param {number} stackIndex - The index in the stack.
+   */
+  fetchPreviousState(stackIndex) {
+    this.level = this.stack[stackIndex].level;
+    this.stack.splice(stackIndex);
+  }
+
+  /**
+   * Checks if the specified section at the given index is a leaf section.
+   *
+   * @param {number} sectionIndex - The index of the section.
+   *
+   * @returns {boolean} - True if the section is a leaf section, false otherwise.
+   */
+  isLeafSection(sectionIndex) {
+    return this.level[sectionIndex]?.isLeaf();
+  }
+
+  /**
+   * Retrieves the node at the specified section and node indices.
+   *
+   * @param {number} sectionIndex - The index of the section.
+   * @param {number} nodeIndex - The index of the node.
+   *
+   * @returns {any} - The retrieved node.
+   */
+  retrieveNode(sectionIndex, nodeIndex) {
+    return this.level[sectionIndex]?.nodes[nodeIndex];
+  }
+
+  /**
+   * Gets the root level of the content tree.
+   *
+   * @returns {Array<Section>} - The root level of the content tree.
+   */
+  get root() {
+    return this.stack[0]?.level || this.level;
+  }
+
+  /**
+   * Return the current state of this manager as query params that are parsable
+   * by {@link #initialize}.
+   *
+   * @returns {{}|{bu: string, section: string, nodes?: string}} The current state as query params.
+   */
+  get params() {
+    if (this.stack.length === 0) {
+      return {};
+    }
+
+    const root = this.stack[0];
+    const rootSection = root.level[root.sectionIndex].toLowerCase();
+    const nodes = this.stack.slice(1).map(n => {
+      const node = n.level[n.sectionIndex].nodes[n.nodeIndex];
+
+      return node.id || node.urn;
+    });
+    let params = {
+      section: toKebabCase(rootSection.title),
+      bu: rootSection.nodes[root.nodeIndex]
+    };
+
+    if (nodes && nodes.length) {
+      params['nodes'] = nodes.join(',');
+    }
+
+    return params;
+  }
+
+
+  /**
+   * Finds the index of a section based on its title in kebab case.
+   *
+   * @private
+   * @param {string} sectionStr - The section title to find.
+   * @returns {number} - The index of the section.
+   *
+   * @example
+   * const index = stateManager.#findSectionIndex("Products");
+   */
+  #findSectionIndex(sectionStr) {
+    const normalizedSectionStr = toKebabCase(sectionStr).toLowerCase();
+
+    return this.level
+      .map(s => toKebabCase(s.title).toLowerCase())
+      .findIndex(title => title === normalizedSectionStr);
+  }
+
+  /**
+   * Finds the index of a node based on its string representation.
+   *
+   * @private
+   * @param {Array<Node>} nodes - The array of nodes to search.
+   * @param {string} str - The string representation of the node to find.
+   *
+   * @returns {number} - The index of the node.
+   */
+  #findNodeIndex(nodes, str) {
+    const normalizedStr = str.toLowerCase();
+
+    return nodes
+      .map(n => (n.urn || n.id || n.toString()).toLowerCase())
+      .findIndex(n => n === normalizedStr);
+  }
+}
+
+export default ListsPageStateManager;


### PR DESCRIPTION
## Description

Closes #109

Query parameters have been added to the URL whenever a section is opened on the lists page, making it navigable through the browser history stack. Examples of decoded urls :

```text
/lists?section=tv-topics&bu=rts&nodes=urn:rts:topic:tv:665
/lists?section=radio-shows&bu=rts&nodes=a9e7621504c6959e35c3ecbe7f6bed0446cdf8da,urn:rts:show:radio:9801398
```

## Changes made

Refactor the state management of the lists page to introduce the `ListsPageStateManager` class. This class facilitates navigation and retrieval of section data. 

