### PR TITLE
fix(srgssr-middleware): akamai token generation

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -47,7 +47,9 @@ class SrgSsr {
    * @returns {Promise<Array.<Object>>}
    */
   static async composeAkamaiResources(resources = []) {
-    if (!AkamaiTokenService.hasToken(resources)) Promise.resolve(resources);
+    if (!AkamaiTokenService.hasToken(resources)) {
+      return Promise.resolve(resources);
+    }
 
     // TODO allow to modify the Akamai URL
     return AkamaiTokenService.tokenizeSources(resources);

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -87,6 +87,20 @@ describe('SrgSsr', () => {
       expect(await SrgSsr.composeAkamaiResources([])).toHaveLength(0);
     });
 
+    it('should not tokenize a resource', () => {
+      const spyOnTokenizeSources = jest.spyOn(AkamaiTokenService, 'tokenizeSources');
+      const resources = [
+        {
+          streaming: 'HLS',
+          tokenType: 'NONE',
+        }
+      ];
+
+      SrgSsr.composeAkamaiResources(resources);
+
+      expect(spyOnTokenizeSources).not.toHaveBeenCalled();
+    });
+
     it('should return an array of resources', async () => {
       const resources = [
         {


### PR DESCRIPTION
## Description

The Akamai token was generated for all URNs, regardless of whether or not they were protected by an Akamai token.

This was due to the fact that the `return` statement was missing from the condition used to check whether or not a resource was protected by an Akamai token.

## Changes made

- add missing `return` statement to the `composeAkamaiResources` function
- add a test case checking that the token is not generated if the resource doesn't require it

