### PR TITLE
chore(github-actions): add Crowdin workflows

### DIFF
--- a/.github/workflows/download-crowding.yml
+++ b/.github/workflows/download-crowding.yml
@@ -1,0 +1,38 @@
+name: Download translations from Crowdin
+
+on:
+  schedule:
+    # runs every 12 hours
+    - cron: '0 */12 * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  crowdin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Synchronize with Crowdin
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+
+          base_path: 'pillarbox-web'
+          source: 'src/lang/en.json'
+          translation: 'src/lang/%locale%.%file_extension%'
+
+          create_pull_request: true
+          localization_branch_name: 'chore/i18n_crowdin_translations'
+          commit_message: 'chore(i18n): new %language% translations'
+          pull_request_base_branch_name: 'main'
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'Add %language% translations dowloaded from Crowdin'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/upload-crowding.yml
+++ b/.github/workflows/upload-crowding.yml
@@ -1,0 +1,27 @@
+name: Upload translations to Crowdin
+
+on:
+  push:
+    paths: ['srg/lang/**']
+    branches: [main]
+
+jobs:
+  crowdin-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Crowdin push
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: true
+          upload_translations: true
+          download_translations: false
+
+          base_path: 'pillarbox-web'
+          source: 'src/lang/en.json'
+          translation: 'src/lang/%locale%.%file_extension%'
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
## Description

Resolves #70 by adding two GitHub actions for downloading and uploading translations to Crowdin.

## Changes made

- `upload_crowdin.yml`, sends translation files to Crowdin only if `src/lang/**` folder has been modified
- `download_crowdin.yml`, downloads translation files from Crowdin `every 12 hours` and creates a pull request to main if translations have been modified


