### PR TITLE
chore(demo): player captions settings focus

### DIFF
--- a/demo/scss/player.scss
+++ b/demo/scss/player.scss
@@ -387,6 +387,10 @@
     background: #333;
     border: none;
     appearance: auto;
+
+    &:focus-within {
+      outline: solid;
+    }
   }
 
   .vjs-modal-dialog.vjs-text-track-settings {


### PR DESCRIPTION
## Description

When navigating with the keyboard, the focus is not correctly set on the `select` html elements of the captions settings.

This is caused by two css rules in two different files:

1. **player.scss**, `select` set to `all:unset`
2. **index.scss**, `select` set to `outline:none`

## Changes made

- Set `outline` to `solid` during `focus-within`. This solution was preferred while waiting for the end of the transition to Lit.

