### PR TITLE
chore(demo): button min height

### DIFF
--- a/demo/scss/index.scss
+++ b/demo/scss/index.scss
@@ -157,10 +157,12 @@ dialog::backdrop {
 .content-btn {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: var(--size-2);
+  justify-content: center;
   width: 100%;
+  min-height: var(--size-10);
   margin: 0 0;
-  padding: var(--size-4) var(--size-3);
+  padding-inline: var(--size-3);
   text-align: justify;
 
   &:first-of-type {
@@ -183,7 +185,6 @@ dialog::backdrop {
   display: flex;
   align-items: center;
   width: 100%;
-  margin-top: var(--size-2);
 
   * {
     color: var(--color-6);


### PR DESCRIPTION
## Description

Defines a minimum height for all buttons to ensure visual consistency.

<img src="https://github.com/SRGSSR/pillarbox-web/assets/34163393/98e3da48-2874-4ace-b525-03a876152177" width=45%>
<img src="https://github.com/SRGSSR/pillarbox-web/assets/34163393/916e72d1-65af-4635-b96d-96162955c1ad" width=45%>

## Changes made

- center button content and set minimum height

