### PR TITLE
fix(demo): dispose the player after closing the modal 

### DIFF
--- a/demo/src/player/player-dialog.js
+++ b/demo/src/player/player-dialog.js
@@ -4,12 +4,12 @@
  *
  * @module
  */
-import Pillarbox from '../../../src/pillarbox';
+import { createPlayer, destroyPlayer } from './player';
 
 const dialog = document.getElementById('pbw-dialog');
 
 // Pauses de video once the modal is closed.
-dialog.addEventListener('close', () => Pillarbox.getPlayer('player').pause());
+dialog.addEventListener('close', destroyPlayer);
 
 // Close the dialog on close button clicked
 dialog.querySelector('#pbw-dialog-close-btn').addEventListener('click', () => {
@@ -38,13 +38,9 @@ dialog.addEventListener('click', (e) => {
  * @param {object} [options.keySystems] - (Optional) The DRM configuration for DRM protected sources.
  */
 export const openPlayerModal = ({ src, type, keySystems }) => {
-  const player = Pillarbox.getPlayer('player');
+  const player = createPlayer();
 
-  if (player.currentSrc() !== src) {
-    player.reset();
-    player.src({ src, type, keySystems });
-  }
-
+  player.src({ src, type, keySystems });
   dialog.showModal();
   dialog.classList.toggle('slide-up-fade-in', true);
 };

--- a/demo/src/player/player.js
+++ b/demo/src/player/player.js
@@ -6,26 +6,45 @@
 import Pillarbox from '../../../src/pillarbox.js';
 import '../../../src/middleware/srgssr.js';
 
-const player = new Pillarbox('player', {
-  fill: true,
-  html5: {
-    vhs: { useForcedSubtitles: true },
-  },
-  liveTracker: {
-    trackingThreshold: 120,
-    liveTolerance: 15,
-  },
-  liveui: true,
-  muted: true,
-  playsinline: true,
-  plugins: { eme: true },
-  responsive: true
-});
+const DEMO_PLAYER_ID = 'player';
+
+/**
+ * Creates and configures a Pillarbox video player.
+ *
+ * @returns {Object} The configured Pillarbox video player instance.
+ */
+export const createPlayer = () => {
+  window.player = new Pillarbox(DEMO_PLAYER_ID, {
+    fill: true,
+    html5: {
+      vhs: { useForcedSubtitles: true },
+    },
+    liveTracker: {
+      trackingThreshold: 120,
+      liveTolerance: 15,
+    },
+    liveui: true,
+    muted: true,
+    playsinline: true,
+    plugins: { eme: true },
+    responsive: true,
+    restoreEl: true
+  });
+
+  return window.player;
+};
+
+/**
+ * Disposes of the Pillarbox video player instance.
+ */
+export const destroyPlayer = () => {
+  Pillarbox.getPlayer(DEMO_PLAYER_ID).dispose();
+  window.player = null;
+};
+
 
 // Expose Pillarbox and player in the window object for debugging
 window.pillarbox = Pillarbox;
-window.player = player;
-
 // TODO must be remove once tagCommander is pillarbox ready
 //
 // Allows to track comscore events

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,51 @@
+# Known Issue
+
+Attempts to load DRM (Digital Rights Management) protected content after calling `player.reset()` may not trigger
+the `webkitneedkey` event. This prevents the initiation of the certificate retrieval process in Safari, resulting in the
+inability to play DRM protected content.
+
+### Issue Details
+
+- **Scenario:** Calling `player.reset()` before loading a new DRM protected source.
+- **Affected Browser:** Safari
+- **Symptoms:** `webkitneedkey` event not fired, leading to video playback issues with DRM-protected content.
+
+### Solutions
+
+To address this issue:
+
+#### Dispose of the player
+
+Instead of calling `player.reset()` you can use the following approach to dispose of a player and reuse the DOM
+element further down the line :
+
+1. **Create the player with the option `restoreEL: true`** : When creating the player make sure that the
+   option `restoreEl` is set to `true`. This will not delete the original DOM element from the DOM once the player is
+   disposed :
+
+   ```javascript
+   const player = new Pillarbox('player-id', {
+    // ---
+    restoreEl: true
+   });
+   ```
+
+2. **Dispose of the player** : When you no longer need the player : `player.dispose()`.
+3. **Recreate the player** : Now you can initialise the player again like in step 1.
+
+#### Reset the `videojs-contrib-eme` plugin
+
+If you *must* call `player.reset()` then you'll have to manually restart the `videojs-contrib-eme` plugin:
+
+1. **Avoid Calling `player.reset()`:** If possible, avoid using `player.reset()` unless absolutely necessary. In many
+   cases, it may not be required.
+
+2. **Reinitialize `videojs-contrib-eme` After `player.reset()`:** If you must call `player.reset()`, reinitialize
+   the `videojs-contrib-eme` plugin afterward to ensure proper handling of DRM-protected content. Example:
+
+    ```javascript
+    // Reinitialize videojs-contrib-eme after calling player.reset() and before loading a new source
+    player.eme({
+        // Add your plugin configuration here
+    });
+    ```


### PR DESCRIPTION
## Description

Closes #113

Calling `player.reset()` before loading a new source was preventing the `webkitneedkey` event
from being listened by `videojs-contrib-eme` resulting in the inability to play DRM protected content.

## Changes made

This commit creates a new player everytime the modal is open in the demo and disposes the player
when closing the modal. Additionally it adds a `KNOWN_ISSUES` document describing the problem with
`player.reset()` and how to mitigate it during the integration of Pillarbox for tracking purposes.
