### PR TITLE
feat(demo): settings page

### DIFF
--- a/demo/src/core/toggle-switch-component.js
+++ b/demo/src/core/toggle-switch-component.js
@@ -1,0 +1,110 @@
+import { html, LitElement, unsafeCSS } from 'lit';
+import { theme } from '../theme/theme';
+import componentCSS from 'bundle-text:./toggle-switch-component.scss';
+
+/**
+ * Custom element representing a toggle switch.
+ *
+ * @element toggle-switch
+ *
+ * @csspart switch - The container for the toggle switch.
+ * @csspart slider - The slider button of the toggle switch.
+ *
+ * @prop {Boolean} checked - Reflects the current state of the toggle switch.
+ * @prop {Boolean} disabled - Indicates whether the toggle switch is disabled.
+ *
+ * @attribute {String} role - ARIA role for accessibility, set to 'switch'.
+ * @attribute {String} tabindex - ARIA tabindex for accessibility, set to '0'.
+ *
+ * @fires ToggleSwitchComponent#change
+ *
+ * @example
+ * <toggle-switch checked></toggle-switch>
+ *
+ * @customElement
+ */
+export class ToggleSwitchComponent extends LitElement {
+  static formAssociated = true;
+  static properties = {
+    checked: { type: Boolean, reflect: true },
+    disabled: { type: Boolean }
+  };
+
+  constructor() {
+    super();
+    this.checked = false;
+    this.disabled = false;
+  }
+
+  static styles = [
+    theme, unsafeCSS(componentCSS)
+  ];
+
+  #onKeyDown = (e) => {
+    if (e.key === ' ') {
+      e.preventDefault();
+      this.toggle();
+    }
+  };
+
+  #onClick = () => {
+    this.toggle();
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'switch');
+    }
+
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', '0');
+    }
+
+    this.addEventListener('click', this.#onClick);
+    this.addEventListener('keydown', this.#onKeyDown);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    this.removeEventListener('click', this.#onClick);
+    this.removeEventListener('keydown', this.#onKeyDown);
+  }
+
+  toggle(force) {
+    if (!this.disabled) {
+      this.checked = force ?? !this.checked;
+    }
+  }
+
+  updated(_changedProperties) {
+    super.updated(_changedProperties);
+
+    if (_changedProperties.has('checked')) {
+      this.setAttribute('aria-checked', this.checked.toString());
+      /**
+       * Custom event dispatched when the state of the toggle switch changes.
+       *
+       * @event ToggleSwitchComponent#change
+       * @type {CustomEvent}
+       * @property {Object} detail - The event detail object.
+       * @property {Boolean} detail.checked - The new state of the toggle switch.
+       */
+      this.dispatchEvent(new CustomEvent('change', { detail: { checked: this.checked }}));
+    }
+
+  }
+
+  render() {
+    return html`
+        <div part="switch">
+            <div part="slider"></div>
+        </div>
+    `;
+  }
+}
+
+
+customElements.define('toggle-switch', ToggleSwitchComponent);

--- a/demo/src/core/toggle-switch-component.scss
+++ b/demo/src/core/toggle-switch-component.scss
@@ -1,0 +1,42 @@
+:host {
+  display: inline-block;
+  cursor: pointer;
+}
+
+[part="switch"] {
+  display: flex;
+  align-items: center;
+  width: var(--size-9);
+  height: var(--size-7);
+  background-color: var(--gray-6);
+  border-radius: var(--radius-4);
+  transition: .4s;
+}
+
+[part="slider"] {
+  display: block;
+  width: var(--size-5);
+  height: var(--size-5);
+  margin-left: var(--size-2);
+  background-color: var(--gray-1);
+  border-radius: var(--radius-round);
+  transition: .4s;
+  content: "";
+}
+
+:host([checked]) [part="switch"] {
+  background-color: var(--green-8);
+}
+
+
+:host([checked]) [part="slider"] {
+  transform: translateX(var(--size-5));
+}
+
+:host([disabled]) [part="switch"] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+
+

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -8,8 +8,19 @@ import './layout/header-component';
 import './router/route-outlet-component';
 import './examples/examples-page';
 import './search/search-page';
+import './settings/settings-page';
 import './lists/lists-page';
 import router from './router/router';
+import PreferencesProvider from './settings/preferences-provider';
+
+const preferences = PreferencesProvider.loadPreferences();
 
 // Initialize the router with the current path or 'examples' if none is found
 router.start({ defaultPath: 'examples' });
+
+if (router.queryParams.debug) {
+  preferences.debug = router.queryParams.debug === 'true';
+  PreferencesProvider.savePreferences(preferences);
+} else if (preferences.debug) {
+  router.updateState({ debug: 'true' });
+}

--- a/demo/src/layout/header-component.js
+++ b/demo/src/layout/header-component.js
@@ -6,6 +6,7 @@ import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import '../router/route-link-component';
 import { theme } from '../theme/theme';
 import headerCSS from 'bundle-text:./header-component.scss';
+import router from '../router/router';
 
 /**
  * A web component that represents the header element of the demo page.
@@ -13,28 +14,58 @@ import headerCSS from 'bundle-text:./header-component.scss';
  * @element pbw-header
  */
 export class HeaderElement extends LitElement {
+  static properties = {
+    debug: { type: Boolean, state: true }
+  };
   static styles = [theme, unsafeCSS(headerCSS)];
+
+  #onRouteUpdated = ({ detail: { queryParams }}) => {
+    this.debug = queryParams.debug === 'true';
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.debug = router.queryParams.debug === 'true';
+    router.addEventListener('routechanged', this.#onRouteUpdated);
+    router.addEventListener('queryparams', this.#onRouteUpdated);
+  }
+
+  disconnectedCallback() {
+    router.removeEventListener('routechanged', this.#onRouteUpdated);
+    router.removeEventListener('queryparams', this.#onRouteUpdated);
+  }
 
   render() {
     return html`
-      <nav>
-        <div class="pbw-title-container">
-          <h1>
-            <img class="pbw-logo" src="${srgssrLogo}"/>
-            <span>Pillarbox</span>
-            <span class="version-txt">${Pillarbox.VERSION.pillarbox}</span>
-          </h1>
-          <a href="https://github.com/srgssr/pillarbox-web" class="github-link"
-             title="Source on Github">
-            ${unsafeSVG(githubLogoSvg)}
-          </a>
-        </div>
-        <div id="pbw-menu" class="pbw-menu">
-          <route-link href="examples">Examples</route-link>
-          <route-link href="search">Search</route-link>
-          <route-link href="lists">Lists</route-link>
-        </div>
-      </nav>
+        <nav>
+            <div class="pbw-title-container">
+                <h1>
+                    <img class="pbw-logo" src="${srgssrLogo}"/>
+                    <span>Pillarbox</span>
+                    <span class="version-txt">${Pillarbox.VERSION.pillarbox}</span>
+                </h1>
+                <a href="https://github.com/srgssr/pillarbox-web"
+                   class="github-link"
+                   title="Source on Github">
+                    ${unsafeSVG(githubLogoSvg)}
+                </a>
+            </div>
+            <div id="pbw-menu" class="pbw-menu">
+                <route-link href="examples${this.debug ? '?debug=true' : ''}">
+                    Examples
+                </route-link>
+                <route-link href="search${this.debug ? '?debug=true' : ''}">
+                    Search
+                </route-link>
+                <route-link href="lists${this.debug ? '?debug=true' : ''}">
+                    Lists
+                </route-link>
+                <route-link href="settings${this.debug ? '?debug=true' : ''}">
+                    Settings
+                </route-link>
+            </div>
+        </nav>
     `;
   }
 }

--- a/demo/src/player/player.js
+++ b/demo/src/player/player.js
@@ -5,8 +5,24 @@
  */
 import Pillarbox from '../../../src/pillarbox.js';
 import '../../../src/middleware/srgssr.js';
+import PreferencesProvider from '../settings/preferences-provider';
 
 const DEMO_PLAYER_ID = 'player';
+const DEFAULT_OPTIONS = {
+  fill: true,
+  html5: {
+    vhs: { useForcedSubtitles: true },
+  },
+  liveTracker: {
+    trackingThreshold: 120,
+    liveTolerance: 15,
+  },
+  liveui: true,
+  playsinline: true,
+  plugins: { eme: true },
+  responsive: true,
+  restoreEl: true
+};
 
 /**
  * Creates and configures a Pillarbox video player.
@@ -14,21 +30,15 @@ const DEMO_PLAYER_ID = 'player';
  * @returns {Object} The configured Pillarbox video player instance.
  */
 export const createPlayer = () => {
+  const preferences = PreferencesProvider.loadPreferences();
+
   window.player = new Pillarbox(DEMO_PLAYER_ID, {
-    fill: true,
-    html5: {
-      vhs: { useForcedSubtitles: true },
-    },
-    liveTracker: {
-      trackingThreshold: 120,
-      liveTolerance: 15,
-    },
-    liveui: true,
-    muted: true,
-    playsinline: true,
-    plugins: { eme: true },
-    responsive: true,
-    restoreEl: true
+    ...DEFAULT_OPTIONS,
+    ...{
+      muted: preferences.muted ?? true,
+      autoplay: preferences.autoplay ?? false,
+      debug: preferences.debug ?? false,
+    }
   });
 
   return window.player;

--- a/demo/src/router/router.js
+++ b/demo/src/router/router.js
@@ -126,12 +126,25 @@ class Router extends EventTarget {
   }
 
   /**
-   * Update the state of the current route (i.e. it's query params).
+   * Updates the state by navigating to the current path with the provided query parameters.
    *
-   * @param {object} queryParams - query parameters to be associated with the route.
+   * @param {Object} queryParams - The new query parameters to be merged with the current ones.
    */
   updateState(queryParams) {
-    this.navigateTo(window.location.pathname, queryParams);
+    this.navigateTo(
+      window.location.pathname,
+      { ...this.#currentQueryParams, ...queryParams }
+    );
+  }
+
+  /**
+   * Replaces the current state by navigating to the current path with the provided query parameters,
+   * discarding the current query parameters.
+   *
+   * @param {Object} newParams - The new query parameters to replace the current ones.
+   */
+  replaceState(newParams) {
+    this.navigateTo(window.location.pathname, newParams);
   }
 
   /**

--- a/demo/src/search/search-bar-component.js
+++ b/demo/src/search/search-bar-component.js
@@ -26,48 +26,39 @@ export class SearchBarComponent extends LitElement {
     this.query = '';
   }
 
-  #change() {
-    const query = this.query ?? '';
-    const bu = this.bu ?? DEFAULT_BU;
-
-    /**
-     * Custom event dispatched by SearchBarComponent when the value of the bar changes.
-     *
-     * @event SearchBarComponent#change
-     * @type {CustomEvent}
-     * @property {Object} detail - The event detail object.
-     * @property {string} detail.query - The query on the search bar.a
-     * @property {string} detail.bu - The selected bu.
-     */
-    this.dispatchEvent(new CustomEvent('change', {
-      detail: { query, bu }
-    }));
-  }
-
   #handleSearchBarKeyUp() {
-    const query = this.renderRoot.querySelector('input').value;
-
-    if (query !== this.query) {
-      this.query = query;
-      this.#change();
-    }
+    this.query = this.renderRoot.querySelector('input').value;
   }
 
   #handleSelectChange(e) {
-    const bu = e.target.value;
+    this.bu = e.target.value;
+  }
 
-    if (bu !== this.bu) {
-      this.bu = bu;
-      this.#change();
+  updated(_changedProperties) {
+    super.updated(_changedProperties);
+
+    if (['bu', 'query'].some(property => _changedProperties.has(property))) {
+      const query = this.query ?? '';
+      const bu = this.bu ?? DEFAULT_BU;
+
+      /**
+       * Custom event dispatched by SearchBarComponent when the value of the bar changes.
+       *
+       * @event SearchBarComponent#change
+       * @type {CustomEvent}
+       * @property {Object} detail - The event detail object.
+       * @property {string} detail.query - The query on the search bar.a
+       * @property {string} detail.bu - The selected bu.
+       */
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: { query, bu }
+      }));
     }
   }
 
   #clearSearchBar() {
-    if (this.query !== '') {
-      this.query = '';
-      this.renderRoot.querySelector('input').value = '';
-      this.#change();
-    }
+    this.query = '';
+    this.renderRoot.querySelector('input').value = '';
   }
 
   render() {

--- a/demo/src/search/search-page.js
+++ b/demo/src/search/search-page.js
@@ -197,7 +197,7 @@ export class SearchPage extends LitElement {
   render() {
     return html`
       <search-bar
-        @change="${(e) => this.#onSearchBarChanged(e.detail.bu, e.detail.query)}">
+        @change="${e => this.#onSearchBarChanged(e.detail.bu, e.detail.query)}">
       </search-bar>
 
       <!-- Search results -->

--- a/demo/src/settings/preferences-provider.js
+++ b/demo/src/settings/preferences-provider.js
@@ -1,0 +1,29 @@
+/**
+ * Utility class for loading and saving preferences to local storage.
+ *
+ * @class PreferencesProvider
+ */
+class PreferencesProvider {
+  /**
+   * Load preferences from local storage.
+   *
+   * @static
+   * @returns {Object} An object representing the loaded preferences.
+   */
+  static loadPreferences() {
+    return JSON.parse(localStorage.getItem('preferences')) || {};
+  }
+
+  /**
+   * Save preferences to local storage.
+   *
+   * @static
+   * @param {Object} preferences - An object representing the preferences to be saved.
+   * @returns {void}
+   */
+  static savePreferences(preferences) {
+    localStorage.setItem('preferences', JSON.stringify(preferences));
+  }
+}
+
+export default PreferencesProvider;

--- a/demo/src/settings/settings-page.js
+++ b/demo/src/settings/settings-page.js
@@ -1,0 +1,73 @@
+import router from '../router/router';
+import { html, LitElement, unsafeCSS } from 'lit';
+import { animations, theme } from '../theme/theme';
+import '../core/toggle-switch-component.js';
+import PreferencesProvider from './preferences-provider';
+import componentCss from 'bundle-text:./settings-page.scss';
+
+/**
+ * A web component that represents the settings page.
+ *
+ * @element settings-page
+ */
+export class SettingsPage extends LitElement {
+  static properties = {
+    autoplay: { type: Boolean, state: true },
+    muted: { type: Boolean, state: true },
+    debug: { type: Boolean, state: true }
+  };
+
+  static styles = [theme, animations, unsafeCSS(componentCss)];
+
+  constructor() {
+    super();
+    const preferences = PreferencesProvider.loadPreferences();
+
+    this.autoplay = preferences.autoplay ?? false;
+    this.muted = preferences.muted ?? true;
+    this.debug = preferences.debug ?? false;
+  }
+
+  updated(_changedProperties) {
+    super.updated(_changedProperties);
+
+    const preferences = PreferencesProvider.loadPreferences();
+
+    [..._changedProperties.keys()]
+      .filter(property => ['autoplay', 'muted', 'debug'].includes(property))
+      .forEach((property) => preferences[property] = this[property]);
+
+    PreferencesProvider.savePreferences(preferences);
+
+    if (_changedProperties.has('debug')) {
+      router.replaceState(this.debug ? { debug: 'true' } : {});
+    }
+  }
+
+  #renderToggle(property, label) {
+    return html`
+      <div part="toggle-container">
+        <label for="${property}-switch" part="label">${label}</label>
+        <toggle-switch id="${property}-switch"
+                       part="toggle-switch"
+                       exportparts="slider, switch"
+                       ?checked="${this[property]}"
+                       @change="${(e) => this[property] = e.detail.checked}">
+        </toggle-switch>
+      </div>
+    `;
+  }
+  render() {
+    return html`
+      <div class="fade-in" @animationend="${e => e.target.classList.remove('fade-in')}">
+        <h2 part="title">Player Settings</h2>
+        ${this.#renderToggle('autoplay', 'Autoplay')}
+        ${this.#renderToggle('muted', 'Player starts muted')}
+        ${this.#renderToggle('debug', 'Enable debug mode')}
+      </div>
+    `;
+  }
+}
+
+customElements.define('settings-page', SettingsPage);
+router.addRoute('settings', 'settings-page');

--- a/demo/src/settings/settings-page.scss
+++ b/demo/src/settings/settings-page.scss
@@ -1,0 +1,40 @@
+[part="title"] {
+  margin: 0;
+  padding: var(--size-3) 0;
+}
+
+[part="toggle-container"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0;
+  color: var(--color-0);
+  font-weight: var(--font-weight-6);
+  font-size: var(--size-3);
+  text-align: justify;
+  background-color: var(--color-9);
+  border: 1px solid var(--color-10);
+
+  &:first-of-type {
+    border-radius: var(--radius-3) var(--radius-3) 0 0;
+  }
+
+  &:last-of-type {
+    border-radius: 0 0 var(--radius-3) var(--radius-3);
+  }
+}
+
+[part="label"] {
+  flex: 1;
+  line-height: var(--size-8);
+  cursor: pointer;
+  padding-inline: var(--size-3);
+}
+
+
+[part="toggle-switch"] {
+  display: flex;
+  align-items: center;
+  height: var(--size-8);
+  padding-inline: var(--size-3);
+}


### PR DESCRIPTION
## Description

Closes #114

Implemented a settings page for the demo. The following features were introduced:

- **Toggle-switch Web Component:** A `toggle-switch web component, mirroring the design of an Apple settings toggle.

- **Settings Page:** Added a settings page that allows users to toggle the following settings:
  - **Autoplay:** The player in the demo page will autoplay when opened (default: false).
  - **Muted:** The player will launch muted (default: true).
  - **Debug Mode:** The player operates in debug mode, and logs can be viewed in the browser's console (default: false).

ll settings are stored in the local storage, ensuring that the demo page remembers user preferences across sessions.

When the debug mode is enabled, a query parameter "debug" is appended to the URL.

<img width="506" alt="image" src="https://github.com/SRGSSR/pillarbox-web/assets/11271371/1a4126a0-a5e4-4606-81fb-364a4ae5c143">


