### PR TITLE
chore(demo): remove scrolling when the dialog is open

### DIFF
--- a/demo/src/player/player-dialog.js
+++ b/demo/src/player/player-dialog.js
@@ -9,7 +9,10 @@ import { createPlayer, destroyPlayer } from './player';
 const dialog = document.getElementById('pbw-dialog');
 
 // Pauses de video once the modal is closed.
-dialog.addEventListener('close', destroyPlayer);
+dialog.addEventListener('close', () => {
+  document.documentElement.style.overflowY = 'scroll';
+  destroyPlayer();
+});
 
 // Close the dialog on close button clicked
 dialog.querySelector('#pbw-dialog-close-btn').addEventListener('click', () => {
@@ -40,6 +43,7 @@ dialog.addEventListener('click', (e) => {
 export const openPlayerModal = ({ src, type, keySystems }) => {
   const player = createPlayer();
 
+  document.documentElement.style.overflowY = 'hidden';
   player.src({ src, type, keySystems });
   dialog.showModal();
   dialog.classList.toggle('slide-up-fade-in', true);


### PR DESCRIPTION
## Description

Modifies the behavior of the dialog in the demo by preventing background from being scrollable when the dialog is open. 

## Changes made

Forces the `overflow-y` style of the `document.documentElement` to be `hidden` when the dialog is opened, and restores it to `scroll` when the dialog is closed.
