### PR TITLE
feat(demo): Open Player from Query Params

### DIFF
--- a/demo/src/search/search-page.js
+++ b/demo/src/search/search-page.js
@@ -49,16 +49,11 @@ export class SearchPage extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.#onQueryParamsChanged = async () => {
-      const query = router.queryParams.query ?? '';
-      const bu = router.queryParams.bu ?? 'rsi';
+    this.#onQueryParamsChanged = () => {
       const searchBar = this.renderRoot.querySelector('search-bar');
 
-      if (searchBar.query !== query || searchBar.bu !== bu) {
-        searchBar.query = query;
-        searchBar.bu = bu;
-        await this.#search(bu, query);
-      }
+      searchBar.query = router.queryParams.query ?? '';
+      searchBar.bu = router.queryParams.bu ?? 'rsi';
     };
     router.addEventListener('queryparams', this.#onQueryParamsChanged);
   }
@@ -69,10 +64,12 @@ export class SearchPage extends LitElement {
     router.removeEventListener('queryparams', this.#onQueryParamsChanged);
   }
 
-  firstUpdated(_changedProperties) {
+  async firstUpdated(_changedProperties) {
     super.firstUpdated(_changedProperties);
+    const searchBar = this.renderRoot.querySelector('search-bar');
 
     this.#onQueryParamsChanged();
+    await this.#search(searchBar.bu, searchBar.query);
   }
 
   async #onSearchBarChanged(bu, query) {


### PR DESCRIPTION
## Description

Closes #134 

Modified the player dialog to listen for changes in the router, allowing it to open the dialog based on specific query parameters.

This change is integrated with all current pages of the demo.

## Changes made

- When the player dialog is open, query parameters are updated to reflect the "src", "type" and "keySystems" that are used to initialize the player content.
- Upon closing the dialog, these query parameters are deleted from the url, other parameters are preserved.
- The "keySystems" parameter is flattened into three separate parameters: "vendor", "licenseUrl", and "certificateUrl."

