### PR TITLE
feat(pillarbox): enable smooth seeking by default

### DIFF
--- a/demo/src/player/player.js
+++ b/demo/src/player/player.js
@@ -9,7 +9,6 @@ import PreferencesProvider from '../settings/preferences-provider';
 
 const DEMO_PLAYER_ID = 'player';
 const DEFAULT_OPTIONS = {
-  enableSmoothSeeking: true,
   fill: true,
   html5: {
     vhs: { useForcedSubtitles: true },

--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -21,6 +21,11 @@ class Pillarbox extends videojs {
   }
 }
 
+/**
+ * Enable smooth seeking for Pillarbox.
+ * @type {boolean}
+ */
+Pillarbox.options.enableSmoothSeeking = true;
 Pillarbox.options.srgOptions = {
   dataProviderHost: undefined,
   tagCommanderScriptURL: undefined,

--- a/test/pillarbox.spec.js
+++ b/test/pillarbox.spec.js
@@ -16,6 +16,12 @@ describe('Pillarbox', () => {
     expect(pillarbox.id()).toEqual('player');
   });
 
+  describe('options', () => {
+    it('should have enableSmoothSeeking set to true by default', () => {
+      expect(Pillarbox.options.enableSmoothSeeking).toBe(true);
+    });
+  });
+
   describe('VERSION', () => {
     it('should contain the version provided by the package.json file', () => {
       expect(Pillarbox.VERSION.pillarbox).toEqual(version);


### PR DESCRIPTION
## Description

Closes #155 by enabling smooth seeking by default for Pillarbox. This feature improves the user experience by providing smoother interaction with the progress bar.

[Screencast from 03. 01. 24 15:21:49.webm](https://github.com/SRGSSR/pillarbox-web/assets/34163393/53d1e3f3-4530-401b-a2c9-732945b0e2ce)


## Changes made

- **Pillarbox** `options` `enableSmoothSeeking` property is set to `true`
- add a test case
- **Demo player**, remove the `enableSmoothSeeking` from `DEFAULT_OPTIONS`