### PR TITLE
feat(demo): use links instead of buttons

### DIFF
--- a/demo/src/core/content-link-component.js
+++ b/demo/src/core/content-link-component.js
@@ -1,0 +1,56 @@
+import router from '../router/router';
+import { html, LitElement, unsafeCSS } from 'lit';
+import componentCSS from 'bundle-text:./content-link-component.scss';
+
+/**
+ * A component for rendering a content link.
+ *
+ * @prop {string} href - The URL to navigate to.
+ * @prop {string} title - The title attribute for the link.
+ *
+ * @csspart a - The anchor element.
+ * @csspart title - The title span within the anchor.
+ * @csspart description - The slot for additional description content within the anchor.
+ *
+ * @example
+ * <content-link href="/example" title="Example Link">
+ *   Additional Description Content
+ * </content-link>
+ */
+export class ContentLinkComponent extends LitElement {
+  static properties = {
+    href: {}
+  };
+
+  static styles = unsafeCSS(componentCSS);
+
+  #onClick = (event) => {
+    event.preventDefault();
+
+    const url = new URL(`${window.location.origin}/${this.href}`);
+    const queryParams = Object.fromEntries(url.searchParams.entries());
+
+    router.navigateTo(url.pathname, queryParams);
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('click', this.#onClick);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('click', this.#onClick);
+  }
+
+  render() {
+    return html`
+      <a href="${this.href}" title="${this.title}" part="a">
+        <span part="title">${this.title}</span>
+        <slot part="description" name="description"></slot>
+      </a>
+    `;
+  }
+}
+
+customElements.define('content-link', ContentLinkComponent);

--- a/demo/src/core/content-link-component.scss
+++ b/demo/src/core/content-link-component.scss
@@ -1,0 +1,38 @@
+[part="a"] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-2);
+  justify-content: center;
+  min-height: var(--size-10);
+  margin: 0 0;
+  color: var(--color-0);
+  font-weight: var(--font-weight-6);
+  font-size: var(--size-3);
+  text-align: justify;
+  text-decoration: none;
+  background-color: var(--color-9);
+  border: 1px solid var(--color-10);
+  transition: background-color 0.4s, border-color 0.4s;
+  padding-inline: var(--size-3);
+
+  &:hover {
+    text-decoration: none;
+    background-color: var(--color-8);
+    border-color: var(--color-9);
+  }
+}
+
+[part="title"] {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+::slotted([slot="description"]) {
+  display: flex;
+  align-items: center;
+  color: var(--color-6);
+  font-weight: var(--font-weight-5);
+  font-size: var(--size-3);
+  font-style: italic;
+}

--- a/demo/src/examples/examples-page.js
+++ b/demo/src/examples/examples-page.js
@@ -2,8 +2,9 @@ import router from '../router/router';
 import { css, html, LitElement } from 'lit';
 import { animations, theme } from '../theme/theme';
 import './load-media-form-component';
+import '../core/content-link-component';
 import Examples from './examples';
-import { openPlayerModal } from '../player/player-dialog';
+import { asQueryParams, openPlayerModal } from '../player/player-dialog';
 import { map } from 'lit/directives/map.js';
 import { when } from 'lit/directives/when.js';
 
@@ -23,22 +24,6 @@ export class ExamplesPage extends LitElement {
       }`
   ];
 
-  #openExample(event) {
-    const exampleEl = event.target.closest('button');
-
-    // Check if the clicked element is a button and has the 'section' dataset attribute.
-    if (!exampleEl || !('section' in exampleEl.parentNode.dataset)) return;
-
-
-    const parent = exampleEl.parentNode;
-    const section = parent.dataset.section;
-    const exampleIdx = Array.from(parent.children)
-      .filter(child => child.tagName.toLowerCase() === 'button')
-      .indexOf(exampleEl);
-
-    openPlayerModal(Examples[section][exampleIdx]);
-  }
-
   render() {
     return html`
       <load-media-form @submit-media="${e => openPlayerModal(e.detail)}">
@@ -46,22 +31,17 @@ export class ExamplesPage extends LitElement {
 
       <!-- List of examples -->
       <div class="fade-in"
-           @animationend="${e => e.target.classList.remove('fade-in')}"
-           @click="${this.#openExample.bind(this)}">
+           @animationend="${e => e.target.classList.remove('fade-in')}">
         ${map(Object.entries(Examples), ([section, examples]) => html`
           <div class="example-section" data-section="${section}">
             <h2 class="sticky">${section}</h2>
             ${map(examples, example => html`
-              <button class="content-btn"
-                      title="${example.description || example.title}">
-                <span class="content-btn-title">
-                  ${example.description || example.title}
-                </span>
+              <content-link title="${example.description || example.title}"
+                            href="examples?${asQueryParams(example)}">
                 ${when(example.description, () => html`
-                  <div class="content-btn-metadata-container">
-                    <span class="content-btn-info">${example.title}</span>
-                  </div>`)}
-              </button>
+                    <span slot="description">${example.title}</span>
+                `)}
+              </content-link>
             `)}
           </div>
         `)}

--- a/demo/src/examples/load-media-form-component.js
+++ b/demo/src/examples/load-media-form-component.js
@@ -117,7 +117,7 @@ export class LoadMediaFormComponent extends LitElement {
   #drmSettingsTemplate() {
     return html`
       <form class="drm-settings-container ${this.drmSettingsShown ? 'fade-in' : 'hidden'}"
-            aria-hidden="${this.drmSettingsShown}"
+            aria-hidden="${!this.drmSettingsShown}"
             @reset="${this.#initDrmSettings}"
             @animationend="${e => e.target.classList.remove('fade-in')}">
         <h3>DRM Settings</h3>

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -4,6 +4,7 @@
  * @module
  */
 import './player/player';
+import './player/player-dialog';
 import './layout/header-component';
 import './router/route-outlet-component';
 import './examples/examples-page';

--- a/demo/src/lists/lists-page-state-manager.js
+++ b/demo/src/lists/lists-page-state-manager.js
@@ -121,13 +121,17 @@ class ListsPageStateManager {
    * @returns {{}|{bu: string, section: string, nodes?: string}} The current state as query params.
    */
   get params() {
-    if (this.stack.length === 0) {
+    return ListsPageStateManager.#params(this.stack);
+  }
+
+  static #params(stack) {
+    if (stack.length === 0) {
       return {};
     }
 
-    const root = this.stack[0];
+    const root = stack[0];
     const rootSection = root.level[root.sectionIndex];
-    const nodes = this.stack.slice(1).map(n => {
+    const nodes = stack.slice(1).map(n => {
       const node = n.level[n.sectionIndex].nodes[n.nodeIndex];
 
       return node.id || node.urn;
@@ -144,6 +148,11 @@ class ListsPageStateManager {
     return params;
   }
 
+  paramsAt(sectionIndex, nodeIndex) {
+    return ListsPageStateManager.#params(
+      [...this.stack, { level: this.level, sectionIndex, nodeIndex }]
+    );
+  }
 
   /**
    * Finds the index of a section based on its title in kebab case.

--- a/demo/src/player/player-dialog.js
+++ b/demo/src/player/player-dialog.js
@@ -14,13 +14,7 @@ dialog.addEventListener('close', () => {
   document.documentElement.style.overflowY = 'scroll';
   destroyPlayer();
 
-  const params = router.queryParams;
-  const keysToRemove = ['src', 'type', 'vendor', 'certificateUrl', 'licenseUrl'];
-  const filteredParams = Object.fromEntries(
-    Object.entries(params).filter(([key]) => !keysToRemove.includes(key))
-  );
-
-  router.replaceState(filteredParams);
+  router.updateState({}, ['src', 'type', 'vendor', 'certificateUrl', 'licenseUrl']);
 });
 
 // Close the dialog on close button clicked
@@ -74,6 +68,9 @@ export const openPlayerModal = ({ src, type, keySystems }) => {
   dialog.classList.toggle('slide-up-fade-in', true);
 };
 
+export const asQueryParams = ({ src, type, keySystems }) => {
+  return new URLSearchParams({ src, type, ...toParams(keySystems) }).toString();
+};
 
 const toKeySystem = (params) => {
   if (!params.vendor) {
@@ -88,8 +85,7 @@ const toKeySystem = (params) => {
   return keySystem;
 };
 
-// Only listen for 'routechanged' events since opening the modal in this fashion is only useful on the first load of the page.
-router.addEventListener('routechanged', (e) => {
+const loadPlayerFromRouter = (e) => {
   const params = e.detail.queryParams;
 
   if ('src' in params) {
@@ -98,4 +94,7 @@ router.addEventListener('routechanged', (e) => {
 
     openPlayerModal({ src, type, keySystems });
   }
-});
+};
+
+router.addEventListener('routechanged', loadPlayerFromRouter);
+router.addEventListener('queryparams', loadPlayerFromRouter);

--- a/demo/src/search/search-page.scss
+++ b/demo/src/search/search-page.scss
@@ -50,4 +50,3 @@ intersection-observer::part(sentinel) {
   border-radius: var(--radius-3);
   animation: var(--animation-blink);
 }
-

--- a/demo/src/theme/theme.scss
+++ b/demo/src/theme/theme.scss
@@ -108,48 +108,14 @@ dialog::backdrop {
   background: rgba(0, 0, 0, 0.5);
 }
 
-
-.content-btn {
-  display: flex;
-  flex-direction: column;
-  gap: var(--size-2);
-  justify-content: center;
-  width: 100%;
-  min-height: var(--size-10);
-  margin: 0 0;
-  padding-inline: var(--size-3);
-  text-align: justify;
-
-  &:first-of-type {
+content-link {
+  &:first-of-type::part(a) {
     border-radius: var(--radius-3) var(--radius-3) 0 0;
   }
 
-  &:last-of-type {
+  &:last-of-type::part(a) {
     border-radius: 0 0 var(--radius-3) var(--radius-3);
   }
-}
-
-.content-btn-title {
-  width: 100%;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.content-btn-metadata-container {
-  display: flex;
-  align-items: center;
-  width: 100%;
-
-  * {
-    color: var(--color-6);
-    font-weight: var(--font-weight-5);
-    font-size: var(--size-3);
-  }
-}
-
-.content-btn-info {
-  font-style: italic;
 }
 
 .warning-text {


### PR DESCRIPTION
## Description

Closes #149
Closes #150

This change refactors all the content buttons of the demo application into links enabling sharing and further navigation options.

## Changes made

- Created a `ContentLinkComponent` that implements a link within the application with the look of the previous buttons but replaces them for links.
- Refactored all buttons on the "Examples," "Search," and "Lists" pages of the demo application to use the newly created component.
- Corrected a regression introduced in the application's router regarding the base url.