### PR TITLE
chore(demo): add playsinline option

### DIFF
--- a/demo/player.html
+++ b/demo/player.html
@@ -51,6 +51,7 @@
         trackingThreshold: 120,
         liveTolerance: 30,
       },
+      playsinline: true,
       plugins: {
         eme: true,
       },


### PR DESCRIPTION
## Description

Adds the `playsinline` option so that the player doesn't automatically go to full screen on iOS.

## Changes made

- Add `playsinline` option to player initialization