### PR TITLE
feat(pillarbox): add default options for pillarbox

### DIFF
--- a/demo/player.html
+++ b/demo/player.html
@@ -46,15 +46,6 @@
       debug,
       fill: true,
       language,
-      liveui: true,
-      liveTracker: {
-        trackingThreshold: 120,
-        liveTolerance: 30,
-      },
-      plugins: {
-        eme: true,
-      },
-      responsive: true,
       srgOptions: {
         dataProviderHost: ilHost
       }

--- a/demo/src/player/player.js
+++ b/demo/src/player/player.js
@@ -10,17 +10,6 @@ import PreferencesProvider from '../settings/preferences-provider';
 const DEMO_PLAYER_ID = 'player';
 const DEFAULT_OPTIONS = {
   fill: true,
-  html5: {
-    vhs: { useForcedSubtitles: true },
-  },
-  liveTracker: {
-    trackingThreshold: 120,
-    liveTolerance: 15,
-  },
-  liveui: true,
-  playsinline: true,
-  plugins: { eme: true },
-  responsive: true,
   restoreEl: true
 };
 

--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -23,13 +23,74 @@ class Pillarbox extends videojs {
 
 /**
  * Enable smooth seeking for Pillarbox.
+ *
+ * @see [Video.js enableSmoothSeeking Option]{@link https://videojs.com/guides/options/#enablesmoothseeking}
  * @type {boolean}
  */
 Pillarbox.options.enableSmoothSeeking = true;
+/**
+ * Configuration options for HTML5 settings in Pillarbox.
+ *
+ * @see [VHS useForcedSubtitles Option]{@link https://github.com/videojs/http-streaming/blob/main/README.md#useforcedsubtitles}
+ * @type {Object}
+ * @property {Object} vhs - Configuration for the Video.js HTTP Streaming.
+ * @property {boolean} useForcedSubtitles - Enables the player to display forced subtitles by default.
+ * Forced subtitles are pieces of information intended for display when no other text representation
+ * is selected. They are used to clarify dialogue, provide alternate languages, display texted graphics,
+ * or present location/person IDs that are not otherwise covered in the dubbed/localized audio.
+ */
+Pillarbox.options.html5 = {
+  vhs: { useForcedSubtitles: true }
+};
+/**
+ * Configuration for the live tracker.
+ *
+ * @see [Video.js liveTracker Option]{@link https://videojs.com/guides/options/#livetrackertrackingthreshold}
+ * @type {Object}
+ * @property {number} trackingThreshold - A threshold that controls when the liveui should be shown.
+ * @property {number} liveTolerance - An option that controls how far from the seekable end should be considered live playback.
+ */
+Pillarbox.options.liveTracker = {
+  trackingThreshold: 120,
+  liveTolerance: 15,
+};
+/**
+ * Allows the player to use the live ui that includes:
+ *
+ * - A progress bar for seeking within the live window
+ * - A button that can be clicked to seek to the live edge with a circle indicating if you are at the live edge or not.
+ *
+ * @see [Video.js liveui Option]{@link https://videojs.com/guides/options/#liveui}
+ * @type {boolean}
+ */
+Pillarbox.options.liveui = true;
+/**
+ * Indicates that the video is to be played "inline", that is within the element's playback area.
+ *
+ * @see [Video element playsinline attribute]{@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#playsinline}
+ * @type {boolean}
+ */
+Pillarbox.options.playsinline = true;
+/**
+ * Configuration for plugins.
+ *
+ * @see [Video.js Plugins Option]{@link https://videojs.com/guides/options/#plugins}
+ * @type {Object}
+ * @property {boolean} eme - Enable the EME (Encrypted Media Extensions) plugin.
+ */
+Pillarbox.options.plugins = { eme: true };
+/**
+ * Enable responsive mode, this will cause the player to customize itself based on responsive breakpoints.
+ *
+ * @see [Video.js Responsive Option]{@link https://videojs.com/guides/options/#responsive}
+ * @type {boolean}
+ */
+Pillarbox.options.responsive = true;
 Pillarbox.options.srgOptions = {
   dataProviderHost: undefined,
   tagCommanderScriptURL: undefined,
 };
 Pillarbox.options.trackers = {};
+
 
 export default Pillarbox;

--- a/test/pillarbox.spec.js
+++ b/test/pillarbox.spec.js
@@ -20,6 +20,35 @@ describe('Pillarbox', () => {
     it('should have enableSmoothSeeking set to true by default', () => {
       expect(Pillarbox.options.enableSmoothSeeking).toBe(true);
     });
+
+    it('should set useForcedSubtitles to true in VHS configuration', () => {
+      expect(Pillarbox.options.html5).toEqual({
+        vhs: { useForcedSubtitles: true }
+      });
+    });
+
+    it('should have liveTracker configuration with default values', () => {
+      expect(Pillarbox.options.liveTracker).toEqual({
+        trackingThreshold: 120,
+        liveTolerance: 15,
+      });
+    });
+
+    it('should have liveui set to true by default', () => {
+      expect(Pillarbox.options.liveui).toBe(true);
+    });
+
+    it('should have playsinline set to true by default', () => {
+      expect(Pillarbox.options.playsinline).toBe(true);
+    });
+
+    it('should have plugins configuration with EME set to true by default', () => {
+      expect(Pillarbox.options.plugins).toEqual({ eme: true });
+    });
+
+    it('should have responsive set to true by default', () => {
+      expect(Pillarbox.options.responsive).toBe(true);
+    });
   });
 
   describe('VERSION', () => {


### PR DESCRIPTION
## Description

Closes #167 by enabling several options by default. These changes enhance the out-of-the-box experience for Pillarbox and improve default functionalities to facilitate a smoother integration process. The options that have been enabled are as follow:

### Live UI

Enabled the Live UI by default, providing the following features:
- A progress bar for seeking within the live window.
- A clickable button to seek to the live edge, accompanied by a circle indicating if the playback is at the live edge.

By default, the threshold for displaying controls within the live window is set to 120 seconds, and live playback is considered within 15 seconds from the seekable end.

### EME

Enabled the EME (Encrypted Media Extensions) plugin by default to support DRM integration and ensure compatibility with protected content.

### Responsive Mode

Enabled responsive mode by default to accommodate a broader range of devices and screen sizes. See [Video.js responsive option](https://videojs.com/guides/options/#responsive) and [Video.js breakpoints](https://videojs.com/guides/options/#breakpoints).

### Inline Mode

Enabled inline mode by default, ensuring content is played within the element's playback area. This prevents, for example, the player from automatically switching to fullscreen on iOS devices.

### Forced subtitles

Enabled the use of forced subtitles by default. Forced subtitles are pieces of information intended for display when no other text representation is selected. They are used to clarify dialogue, provide alternate languages, display texted graphics, or present location/person IDs that are not otherwise covered in the dubbed/localized audio.

## Changes Made

- Set `liveui`, `responsive`, `playsinline`, `plugins.eme` and `html5.vhs.useForcedSubtitles` options to `true` by default.
- Set `liveTracker.trackingThreshold` to `120` seconds and `liveTracker.liveTolerance` to `15` seconds.
- Added test cases to verify default values for each option.
- Documented each option individually, referencing Video.js documentation when available.
- Removed these options from the Demo player as well as the standalone player page.