### PR TITLE
feat(demo): showcase videos with a specified start time

### DIFF
--- a/demo/scss/index.scss
+++ b/demo/scss/index.scss
@@ -41,7 +41,7 @@ html {
 }
 
 body {
-  max-width: var(--size-15);
+  max-width: var(--size-md);
   margin: 0 auto;
   padding: 0 var(--size-2);
   color: var(--color-4);

--- a/demo/src/components/code-block/code-block.js
+++ b/demo/src/components/code-block/code-block.js
@@ -1,0 +1,33 @@
+import { html, LitElement, unsafeCSS } from 'lit';
+import componentCss from 'bundle-text:./code-block.scss';
+import hljs from 'highlight.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html';
+
+export class CodeBlock extends LitElement {
+  static styles = [unsafeCSS(componentCss)];
+  static properties = {
+    language: { type: String },
+    code: { tyoe: String, state: true }
+  };
+
+  constructor(props) {
+    super(props);
+    this.language = 'javascript';
+  }
+
+  #onCodeChanged() {
+    const slottedElements = this.shadowRoot.querySelector('slot').assignedNodes();
+    const codeStr = slottedElements[0].textContent;
+
+    this.code = hljs.highlight(codeStr, { language: this.language }).value;
+  }
+
+  render() {
+    return html`
+      <pre part="container"><code>${unsafeHTML(this.code)}</code></pre>
+      <slot @slotchange="${() => this.#onCodeChanged()}"></slot>
+    `;
+  }
+}
+
+customElements.define('code-block', CodeBlock);

--- a/demo/src/components/code-block/code-block.scss
+++ b/demo/src/components/code-block/code-block.scss
@@ -1,0 +1,10 @@
+@import '~highlight.js/scss/atom-one-dark';
+
+[part="container"] {
+  overflow-x: auto;
+  font-size: var(--font-size-0);
+}
+
+slot {
+  display: none;
+}

--- a/demo/src/components/player/player.js
+++ b/demo/src/components/player/player.js
@@ -17,11 +17,13 @@ const DEFAULT_OPTIONS = {
 };
 
 /**
- * Creates and configures a Pillarbox video player.
+ * Creates and configures a Pillarbox player.
  *
- * @returns {Object} The configured Pillarbox video player instance.
+ * @param {Object} options - (Optional) options to customize the player behaviour.
+ *
+ * @returns {Object} The configured Pillarbox player instance.
  */
-const createPlayer = () => {
+const createPlayer = (options = {}) => {
   const preferences = PreferencesProvider.loadPreferences();
 
   window.player = new Pillarbox(DEMO_PLAYER_ID, {
@@ -30,7 +32,8 @@ const createPlayer = () => {
       muted: preferences.muted ?? true,
       autoplay: preferences.autoplay ?? false,
       debug: preferences.debug ?? false,
-    }
+    },
+    ...options
   });
 
   return window.player;
@@ -119,11 +122,23 @@ router.addEventListener('queryparams', loadPlayerFromRouter);
  * @param {string} options.src - The source URL of the video.
  * @param {string} [options.type] - (Optional) The type/format of the video (e.g., 'video/mp4').
  * @param {object} [options.keySystems] - (Optional) The DRM configuration for DRM protected sources.
+ * @param {object} [options.playerOptions] - (Optional) Additional configuration for the player.
+ * @param {Boolean} shouldUpdateRouter - Whether the router should be updated or not (Default: true).
+ *
+ * @returns {Object} The configured Pillarbox player instance.
  */
-export const openPlayerModal = ({ src, type, keySystems }) => {
-  const player = createPlayer();
+export const openPlayerModal = (
+  { src, type, keySystems, playerOptions },
+  shouldUpdateRouter = true
+) => {
+  const player = createPlayer(playerOptions ?? {});
 
   playerDialog.open = true;
   player.src({ src, type, keySystems });
-  router.updateState({ src, type, ...toParams(keySystems) });
+
+  if (shouldUpdateRouter) {
+    router.updateState({ src, type, ...toParams(keySystems) });
+  }
+
+  return player;
 };

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,16 +5,18 @@
  */
 import './components/dialog/demo-dialog-component';
 import './components/player/player';
-import './layout/header/header-component';
-import './router/route-outlet-component';
 import './layout/content/examples/examples-page';
+import './layout/content/lists/lists-page';
 import './layout/content/search/search-page';
 import './layout/content/settings/settings-page';
-import './layout/content/lists/lists-page';
+import './layout/content/showcase/showcase-page';
+import './layout/header/header-component';
+import './router/route-outlet-component';
 import router from './router/router';
 import PreferencesProvider from './layout/content/settings/preferences-provider';
 
 const preferences = PreferencesProvider.loadPreferences();
+
 
 // Initialize the router with the current path or 'examples' if none is found
 router.start({ defaultPath: 'examples' });

--- a/demo/src/layout/content/examples/load-media-form-component.js
+++ b/demo/src/layout/content/examples/load-media-form-component.js
@@ -99,7 +99,7 @@ export class LoadMediaFormComponent extends LitElement {
                   @click="${() => this.drmSettingsShown = !this.drmSettingsShown}">
             <i class="material-icons-outlined ${classMap(btnSettingsClassMap)}"
                @animationend="${e => e.target.classList.remove('spin', 'spin-back')}">
-              settings
+              key
             </i>
           </button>
         </div>

--- a/demo/src/layout/content/showcase/showcase-component.js
+++ b/demo/src/layout/content/showcase/showcase-component.js
@@ -1,0 +1,55 @@
+import { css, html, LitElement } from 'lit';
+import '../../../components/code-block/code-block';
+import { theme } from '../../../theme/theme';
+
+export class ShowcaseComponent extends LitElement {
+  static styles = [theme, css`
+    ::slotted([slot='demo']) {
+      aspect-ratio: var(--ratio-widescreen);
+    }
+
+    ::slotted([slot='description']) {
+      font-size: var(--font-size-1);
+      border-left: 3px solid var(--color-5);
+      padding-left: var(--size-2);
+      text-align: justify;
+      color: var(--color-4);
+      font-weight: var(--font-weight-1);
+    }
+
+    .hidden {
+      display: none;
+    }
+  `];
+
+  static properties = {
+    hasCodeExample: { type: Boolean, state: true },
+    exampleLanguage: { type: String }
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.addEventListener('slotchange', () => {
+      this.hasCodeExample = this.#hasSlot('code');
+    });
+  }
+
+  #hasSlot(name) {
+    return this.shadowRoot.querySelector(`slot[name="${name}"]`).assignedNodes().length > 0;
+  }
+
+  render() {
+    return html`
+      <slot name="title"></slot>
+      <slot name="description"></slot>
+
+      <div class="${!this.hasCodeExample ? 'hidden' : ''}">
+        <h3>Implementation</h3>
+        <slot name="code"></slot>
+      </div>
+    `;
+  }
+}
+
+
+customElements.define('showcase-component', ShowcaseComponent);

--- a/demo/src/layout/content/showcase/showcase-page.js
+++ b/demo/src/layout/content/showcase/showcase-page.js
@@ -1,0 +1,21 @@
+import router from '../../../router/router';
+import { html, LitElement } from 'lit';
+import { animations, theme } from '../../../theme/theme';
+import './start-time-showcase';
+
+export class ShowCasePage extends LitElement {
+  static styles = [theme, animations];
+
+  render() {
+    return html`
+      <!-- List of showcases -->
+      <div class="fade-in"
+           @animationend="${e => e.target.classList.remove('fade-in')}">
+        <starttime-showcase></starttime-showcase>
+      </div>
+    `;
+  }
+}
+
+customElements.define('showcase-page', ShowCasePage);
+router.addRoute('showcase', 'showcase-page');

--- a/demo/src/layout/content/showcase/start-time-showcase.js
+++ b/demo/src/layout/content/showcase/start-time-showcase.js
@@ -1,0 +1,73 @@
+import { css, html, LitElement } from 'lit';
+import { theme } from '../../../theme/theme';
+import exampleTxt from 'bundle-text:./starttime-example.txt';
+import './showcase-component';
+import { openPlayerModal } from '../../../components/player/player';
+
+/**
+ * This component allows to showcase videos with a specified start time.
+ *
+ * @element starttime-showcase
+ *
+ * @prop {Number} starttime - The start time of the video playback in seconds. Default value: 300.
+ *
+ * @prop {String} src - The source URL of the video. Default value: 'urn:swi:video:48115940'.
+ *
+ * @prop {String} type - The MIME type of the video. It defines the media type of the video file
+ * specified in the `src` property. Default value: 'srsgssr/urn'.
+ *
+ * @example
+ * ```html
+ * <show-case-page starttime="30" src="urn:swi:video:48115940" type="srsgssr/urn"></show-case-page>
+ * ```
+ *
+ * @customElement
+ */
+export class StartTimeShowcase extends LitElement {
+  static styles = [theme, css`button { 
+    width: 100%;
+    margin: var(--size-1) 0;
+    padding: var(--size-4) var(--size-3);
+    border-radius: var(--radius-2);
+  }`];
+  static properties = {
+    starttime: { type: Number },
+    src: { type: String },
+    type: { type: String }
+  };
+  constructor(props) {
+    super(props);
+    this.starttime = 300;
+    this.src = 'urn:swi:video:48115940';
+    this.type = 'srgssr/urn';
+  }
+
+  #openDemo() {
+    const player = openPlayerModal({
+      src: this.src,
+      type: this.type,
+      playerOptions: { trackers: { srgAnalytics: false }}
+    }, false);
+
+    player.on('loadeddata', () => player.currentTime(this.starttime));
+  }
+
+  render() {
+    return html`
+      <showcase-component>
+        <h2 slot="title">Start the player at a given position</h2>
+        <p slot="description">
+          In this showcase, we'll demonstrate how to load a video source and
+          start playback at a specific position using Pillarbox. This can be
+          useful when you want to provide users with the option to begin
+          watching a video from a predefined timestamp. To achieve this
+          functionality, follow the code snippet below:
+        </p>
+        <code-block slot="code" language="javascript">${exampleTxt}</code-block>
+      </showcase-component>
+      <button @click="${() => this.#openDemo()}">Run the demo</button>
+    `;
+  }
+}
+
+customElements.define('starttime-showcase', StartTimeShowcase);

--- a/demo/src/layout/content/showcase/starttime-example.txt
+++ b/demo/src/layout/content/showcase/starttime-example.txt
@@ -1,0 +1,11 @@
+// Create by referencing the video element with its unique ID
+const player = new Pillarbox('video-element-id')
+
+// Load the video source
+player.src({src: 'urn:swi:video:48115940', type: 'srgssr/urn'});
+
+// Listen for the 'loadeddata' event, indicating that the video data has loaded
+player.on('loadeddata', () => {
+  // Set the desired start position in seconds (e.g., start at 5 minutes)
+  player.currentTime(300);
+});

--- a/demo/src/layout/header/header-component.js
+++ b/demo/src/layout/header/header-component.js
@@ -38,33 +38,56 @@ export class DemoHeaderElement extends LitElement {
 
   render() {
     return html`
+      ${this.#renderHeaderElement()}
+      ${this.#renderNavElement()}
+    `;
+  }
+
+  #renderHeaderElement() {
+    return html`
       <header>
         <h1>
           <img class="pbw-logo" src="${srgssrLogo}"/>
           <span>Pillarbox</span>
           <span class="version-txt">${Pillarbox.VERSION.pillarbox}</span>
         </h1>
-        <a href="https://github.com/srgssr/pillarbox-web" class="github-link" title="Source on Github">
-          ${unsafeSVG(githubLogoSvg)}
-        </a>
-      </header>
+        <div class="header-end">
+          <a href="https://github.com/srgssr/pillarbox-web" class="github-link"
+             title="Source on Github">
+            ${unsafeSVG(githubLogoSvg)}
+          </a>
+          <route-link href="settings${this.debug ? '?debug=true' : ''}"
+                      title="Settings">
+            <i class="material-icons-outlined">settings</i>
+          </route-link>
+        </div>
+      </header>`;
+  }
+
+  #renderNavElement() {
+    return html`
       <nav>
         <ul>
           <li>
-            <route-link href="examples${this.debug ? '?debug=true' : ''}">Examples</route-link>
+            <route-link href="examples${this.debug ? '?debug=true' : ''}">
+              Examples
+            </route-link>
           </li>
           <li>
-            <route-link href="search${this.debug ? '?debug=true' : ''}">Search</route-link>
+            <route-link href="search${this.debug ? '?debug=true' : ''}">Search
+            </route-link>
           </li>
           <li>
-            <route-link href="lists${this.debug ? '?debug=true' : ''}">Lists</route-link>
+            <route-link href="lists${this.debug ? '?debug=true' : ''}">Lists
+            </route-link>
           </li>
           <li>
-            <route-link href="settings${this.debug ? '?debug=true' : ''}">Settings</route-link>
+            <route-link href="showcase${this.debug ? '?debug=true' : ''}">
+              Showcase
+            </route-link>
           </li>
         </ul>
-      </nav>
-    `;
+      </nav>`;
   }
 }
 

--- a/demo/src/layout/header/header-component.scss
+++ b/demo/src/layout/header/header-component.scss
@@ -12,11 +12,13 @@ header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  margin: var(--size-4) 0;
 
   h1 {
     display: flex;
     gap: .15em;
     align-items: center;
+    margin: 0;
   }
 }
 
@@ -45,20 +47,48 @@ header {
   }
 }
 
+.header-end {
+  display: flex;
+  align-items: center;
+
+  route-link::part(a) {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+  }
+
+  .material-icons-outlined {
+    font-size: var(--size-7);
+  }
+
+  route-link {
+    margin-left: var(--size-2);
+  }
+}
+
 nav ul {
   margin-bottom: var(--size-4);
 
-  route-link::part(a) {
-    padding: var(--size-1) var(--size-2);
-    border-radius: var(--radius-3);
-    transition: background-color 0.4s, color 0.4s;
+  li {
+    margin-right: var(--size-1);
   }
 
-  route-link::part(a active) {
-    color: var(--color-8);
-    text-decoration: none;
-    background-color: var(--color-5);
-    cursor: default;
-    transition: background-color 0.8s, color 0.4s;
+  li:last-child {
+    margin: 0;
   }
+}
+
+route-link::part(a) {
+  padding: var(--size-1) var(--size-1);
+  font-size: var(--size-4);
+  border-radius: var(--radius-3);
+  transition: background-color 0.4s, color 0.4s;
+}
+
+route-link::part(a active) {
+  color: var(--color-8);
+  text-decoration: none;
+  background-color: var(--color-5);
+  cursor: default;
+  transition: background-color 0.8s, color 0.4s;
 }

--- a/demo/src/router/route-link-component.js
+++ b/demo/src/router/route-link-component.js
@@ -4,8 +4,9 @@ import { animations, theme } from '../theme/theme';
 
 export class RouteLinkCompenent extends LitElement {
   static properties = {
-    href: {},
-    selected: { state: true },
+    href: { type: String },
+    title: { type: String },
+    selected: { type: Boolean, state: true },
   };
 
   static styles = [theme, animations];
@@ -49,6 +50,7 @@ export class RouteLinkCompenent extends LitElement {
     return html`
         <a href="${this.href}"
            aria-disabled="${this.selected}"
+           title="${this.title}"
            part="a ${this.selected ? 'active' : ''}">
             <slot></slot>
         </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "buffer": "^6.0.3",
         "eslint": "^8.55.0",
         "eslint-plugin-jest": "^27.2.2",
+        "highlight.js": "^11.9.0",
         "husky": "^8.0.3",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.6.1",
@@ -11120,6 +11121,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hook-std": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "buffer": "^6.0.3",
     "eslint": "^8.55.0",
     "eslint-plugin-jest": "^27.2.2",
+    "highlight.js": "^11.9.0",
     "husky": "^8.0.3",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.6.1",


### PR DESCRIPTION
## Description

Closes #174

Introduces a new showcase page that displays various demonstrations highlighting the player's capabilities, akin to the existing mobile app showcases:

- Added a showcase on the new page demonstrating how to initiate media playback at a specified start time.
- Added 'highlight.js' for code highlighting purposes.
- Introduced a new web component (`code-block`) that seamlessly integrates with 'highlight.js'.
- Developed a versatile showcase component serving as the foundational building block for all showcases. It includes a description section and an optional implementation section.

## Changes made

- Moved the settings page to the top of the interface, allowing more menu space for improved mobile device usability.
- Updated the icon for DRM settings to differentiate it from the Demo settings icon.
- Expanded the viewport width for larger screens, enhancing readability for showcase content.

