### PR TITLE
chore(npm): update to video.js version 8.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
-        "video.js": "^8.9.0",
+        "video.js": "^8.10.0",
         "videojs-contrib-eme": "^3.11.1"
       },
       "devDependencies": {
@@ -7177,9 +7177,9 @@
       "dev": true
     },
     "node_modules/@videojs/http-streaming": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.9.1.tgz",
-      "integrity": "sha512-bNKlbs+b4NTyZlU3iLXj2glEHfAErjKqQryeEoDQ8FqnlFHzza7ijhMB+d/5BMrfRyiL2SvKrTDjD1CbH8QOFQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.10.0.tgz",
+      "integrity": "sha512-Lf1rmhTalV4Gw0bJqHmH4lfk/FlepUDs9smuMtorblAYnqDlE2tbUOb7sBXVYoXGdbWbdTW8jH2cnS+6HWYJ4Q==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",
@@ -23130,12 +23130,12 @@
       }
     },
     "node_modules/video.js": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.9.0.tgz",
-      "integrity": "sha512-zkDymz4aCGSdPgOoG48W+UqoYU/JYXIr78HLWkjkXvIs0rrvx0hay3w+X9/OzWNM0/5M75somsdxrvQGr/U1TA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.10.0.tgz",
+      "integrity": "sha512-7UeG/flj/pp8tNGW8WKPP1VJb3x2FgLoqUWzpZqkoq5YIyf6MNzmIrKtxprl438T5RVkcj+OzV8IX4jYSAn4Sw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "3.9.1",
+        "@videojs/http-streaming": "3.10.0",
         "@videojs/vhs-utils": "^4.0.0",
         "@videojs/xhr": "2.6.0",
         "aes-decrypter": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "stylelint-order": "^6.0.4"
   },
   "dependencies": {
-    "video.js": "^8.9.0",
+    "video.js": "^8.10.0",
     "videojs-contrib-eme": "^3.11.1"
   }
 }


### PR DESCRIPTION
## Description
This video.js update removes the `X` from the `error-display` and expose the `version` through the player instance.

```javascript
const player = videojs('player');

// Display video.js version
player.version();
```

## Changes made

- update package.json and package-lock.json
