### PR TITLE
chore(github-actions): publish selected pre-release tag as the latest dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,7 @@ jobs:
           registry-url: https://npm.pkg.github.com/
           scope: '@srgssr'
       - run: |
-          npm dist-tag ls @srgssr/pillarbox-web
-          npm dist-tag add @srgssr/pillarbox-web@$(npm view @srgssr/pillarbox-web dist-tags.main) latest
+          npm dist-tag add @srgssr/pillarbox-web@$(echo "${{github.ref_name}}" | cut -c 2-) latest
           exit 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Allows to publish a `pre-release` as a `latest` `dist-tag` directly from the GitHub [releases page](https://github.com/SRGSSR/pillarbox-web/releases).

It is also possible to set an old `tag` as `latest` from the GitHub [releases page](https://github.com/SRGSSR/pillarbox-web/releases):
- if the old tag is a `pre-release`, simply promote it to a `release`
- if the old tag had been marked as `release`, it must be marked as `pre-release`, then as `release`, so that the `released` event is triggered again by GitHub actions

## Changes made

- deletes the first character from `ref_name` to keep only the version number
