### PR TITLE
chore(npm): update to video.js version 8.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
-        "video.js": "^8.10.0",
+        "video.js": "^8.11.1",
         "videojs-contrib-eme": "^3.11.1"
       },
       "devDependencies": {
@@ -23130,9 +23130,9 @@
       }
     },
     "node_modules/video.js": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.10.0.tgz",
-      "integrity": "sha512-7UeG/flj/pp8tNGW8WKPP1VJb3x2FgLoqUWzpZqkoq5YIyf6MNzmIrKtxprl438T5RVkcj+OzV8IX4jYSAn4Sw==",
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.11.1.tgz",
+      "integrity": "sha512-OoIrbdaP8mo3HVCaq3d2SeceFYslsxYj7HrE+GImylXli5QUfcGGcxQraJ5JkzFRYogJi7hCR8lFjgAMDo/FgA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/http-streaming": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "stylelint-order": "^6.0.4"
   },
   "dependencies": {
-    "video.js": "^8.10.0",
+    "video.js": "^8.11.1",
     "videojs-contrib-eme": "^3.11.1"
   }
 }


### PR DESCRIPTION
## Description

Update video.js to version [8.11.1](https://github.com/videojs/video.js/releases/tag/v8.11.1).

## Changes made

- update package.json and package-lock.json