### PR TITLE
feat(srgssr-middleware): use metadata instead of cause when an error occurs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
-        "video.js": "^8.10.0",
+        "video.js": "^8.11.1",
         "videojs-contrib-eme": "^3.11.1"
       },
       "devDependencies": {
@@ -23130,9 +23130,9 @@
       }
     },
     "node_modules/video.js": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.10.0.tgz",
-      "integrity": "sha512-7UeG/flj/pp8tNGW8WKPP1VJb3x2FgLoqUWzpZqkoq5YIyf6MNzmIrKtxprl438T5RVkcj+OzV8IX4jYSAn4Sw==",
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.11.1.tgz",
+      "integrity": "sha512-OoIrbdaP8mo3HVCaq3d2SeceFYslsxYj7HrE+GImylXli5QUfcGGcxQraJ5JkzFRYogJi7hCR8lFjgAMDo/FgA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/http-streaming": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "stylelint-order": "^6.0.4"
   },
   "dependencies": {
-    "video.js": "^8.10.0",
+    "video.js": "^8.11.1",
     "videojs-contrib-eme": "^3.11.1"
   }
 }

--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -31,7 +31,7 @@ class SrgSsr {
     SrgSsr.error(player, {
       code: MediaError.MEDIA_ERR_ABORTED,
       message,
-      cause: { type: blockReason, src: srcMediaObj },
+      metadata: { errorType: blockReason, src: srcMediaObj },
     });
 
     return true;
@@ -149,8 +149,8 @@ class SrgSsr {
     SrgSsr.error(player, {
       code: 0,
       message: player.localize('UNKNOWN'),
-      cause: {
-        type: 'UNKNOWN',
+      metadata: {
+        errorType: 'UNKNOWN',
         urn: player.src(),
         status: error.status,
         statusText: error.statusText,
@@ -167,13 +167,13 @@ class SrgSsr {
    * @param {import('video.js/dist/types/player').default} player
    * @param {Object} error
    */
-  static error(player, { code, message, cause }) {
+  static error(player, { code, message, metadata }) {
     player.error(null);
 
     player.error({
       code,
       message,
-      cause,
+      metadata,
     });
   }
 

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -70,7 +70,7 @@ describe('SrgSsr', () => {
       expect(spyOnError).toHaveBeenCalledWith(player, expect.any(Object));
       expect(spyOnPlayerError.mock.calls[1]).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ cause: { type: 'STARTDATE', src: {}}})
+          expect.objectContaining({ metadata: { errorType: 'STARTDATE', src: {}}})
         ])
       );
     });
@@ -349,7 +349,7 @@ describe('SrgSsr', () => {
       const error = {
         code: 1,
         message: 'error message',
-        cause: 'error cause',
+        metadata: { errorType: 'error metadata' },
       };
 
       SrgSsr.error(player, error);


### PR DESCRIPTION
## Description

Video.js in version [8.11.1](https://github.com/videojs/video.js/releases/tag/v8.11.1) offers the possibility of providing more detail when an error occurs. To this end, the `metadata` property, which is an object, has been added. This object also has an `errorType` property, giving more context on the error that has occurred. Finally, the `metadata` object can host any other `custom property`.

Pillarbox has a similar mechanism, except that instead of naming the `metadata` property, it's called `cause` and has a `type` property. The term `cause` has been borrowed directly from the `Error` object, so as not to introduce a new term.

However, to remain consistent with video.js, the term `cause` has been dropped in favor of `metadata`.

## Changes made

- update of srgssr-middleware
- update unit tests
- update video.js dependency