### PR TITLE
fix: demo page not working on github

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "targets": {
     "main": false,
     "github-page": {
+      "publicUrl": "./",
       "isLibrary": false,
       "outputFormat": "esmodule"
     }


### PR DESCRIPTION
## Description

Adresses a bug that was introduced in #185 by restoring the publicUrl property in the parcel target `github-page` that was dropped.