### PR TITLE
chore(npm): update dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^ 9.2.5",
         "@semantic-release/npm": "^11.0.2",
-        "@types/jest": "^29.5.11",
+        "@types/jest": "^29.5.12",
         "babel-jest": "^29.5.0",
         "buffer": "^6.0.3",
         "eslint": "^8.55.0",
@@ -40,7 +40,7 @@
         "rollup-plugin-filesize": "^10.0.0",
         "sass": "^1.70.0",
         "semantic-release": "^22.0.10",
-        "stylelint": "^16.0.2",
+        "stylelint": "^16.2.1",
         "stylelint-config-rational-order": "^0.1.2",
         "stylelint-order": "^6.0.4",
         "typescript": "^5.3.3"
@@ -8238,9 +8238,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.11",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
-      "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -8611,22 +8611,6 @@
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0",
         "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/mux.js": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.1.tgz",
-      "integrity": "sha512-Omz79uHqYpMP1V80JlvEdCiOW1hiw4mBvDh9gaZEpxvB+7WYb2soZSzfuSRrK2Kh9Pm6eugQNrIpY/Bnyhk4hw==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "global": "^4.4.0"
-      },
-      "bin": {
-        "muxjs-transmux": "bin/transmux.js"
       },
       "engines": {
         "node": ">=8",
@@ -24267,9 +24251,9 @@
       "dev": true
     },
     "node_modules/stylelint": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.2.0.tgz",
-      "integrity": "sha512-gwqU5AkIb52wrAzzn+359S3NIJDMl02TXLUaV2tzA/L6jUdpTwNt+MCxHlc8+Hb2bUHlYVo92YeSIryF2gJthA==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.2.1.tgz",
+      "integrity": "sha512-SfIMGFK+4n7XVAyv50CpVfcGYWG4v41y6xG7PqOgQSY8M/PgdK0SQbjWFblxjJZlN9jNq879mB4BCZHJRIJ1hA==",
       "dev": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^ 9.2.5",
     "@semantic-release/npm": "^11.0.2",
-    "@types/jest": "^29.5.11",
+    "@types/jest": "^29.5.12",
     "babel-jest": "^29.5.0",
     "buffer": "^6.0.3",
     "eslint": "^8.55.0",
@@ -79,7 +79,7 @@
     "rollup-plugin-filesize": "^10.0.0",
     "sass": "^1.70.0",
     "semantic-release": "^22.0.10",
-    "stylelint": "^16.0.2",
+    "stylelint": "^16.2.1",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-order": "^6.0.4",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Description

Running the command `npm outdated` returns the following result:

| Package     | Current | Latest  |
|-------------|---------|---------|
| @types/jest | 29.5.11 | 29.5.12 |
| stylelint   | 16.2.0  | 16.2.1  |

This update allows to close #181 and use the latest versions of various development dependencies.

## Changes made

- updates the `package.json` file
- updates the `package-lock.json` file

