### PR TITLE
chore(npm): update videojs-contrib-eme to version 3.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "video.js": "^8.11.1",
-        "videojs-contrib-eme": "^3.11.1"
+        "videojs-contrib-eme": "^3.11.2"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -8611,22 +8611,6 @@
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0",
         "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/http-streaming/node_modules/mux.js": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.1.tgz",
-      "integrity": "sha512-Omz79uHqYpMP1V80JlvEdCiOW1hiw4mBvDh9gaZEpxvB+7WYb2soZSzfuSRrK2Kh9Pm6eugQNrIpY/Bnyhk4hw==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "global": "^4.4.0"
-      },
-      "bin": {
-        "muxjs-transmux": "bin/transmux.js"
       },
       "engines": {
         "node": ">=8",
@@ -26660,9 +26644,9 @@
       }
     },
     "node_modules/videojs-contrib-eme": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-3.11.1.tgz",
-      "integrity": "sha512-LM95HUCXn/FlrtRzZDF50RPccIu5jcosU60tYzVItX/lTcO6zHisgEuzXqCnCGugzqpDHyAXZi5sCBEbXtS4mw==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-3.11.2.tgz",
+      "integrity": "sha512-PqCXinfo8EqPD+2SNlW8gblLXH9LYAHFqZ0x9yaCPCEZrxh6U+Iln5LgsT3kvRmVjmxSF7a+pQ6P6pvoWgFSRA==",
       "dependencies": {
         "global": "^4.3.2",
         "video.js": "^6 || ^7 || ^8"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
   },
   "dependencies": {
     "video.js": "^8.11.1",
-    "videojs-contrib-eme": "^3.11.1"
+    "videojs-contrib-eme": "^3.11.2"
   }
 }


### PR DESCRIPTION
## Description

For more information, please refer to https://github.com/videojs/videojs-contrib-eme/pull/201

## Changes made

- updates the `package.json` file
- updates the `package-lock.json` file