### PR TITLE
docs: move wiki articles to generated jsdoc site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,14 +19,12 @@ npm install --save @srgssr/pillarbox
 In your HTML file, add the following code to initialize Pillarbox:
 
 ```html
-
 <video-js id="my-player" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
 ```
 
 Import the CSS file in your HTML to apply Pillarbox default theme:
 
 ```html
-
 <link rel="stylesheet" href="node_modules/pillarbox/pillarbox.min.css">
 ```
 
@@ -36,7 +34,7 @@ Finally, import Pillarbox and set up the player:
 import Pillarbox from 'pillarbox';
 
 const player = new Pillarbox('my-player', {// Options... });
-  player.src({ src: 'urn:swi:video:48115940', type: 'srgssr/urn' });
+player.src({ src: 'urn:swi:video:48115940', type: 'srgssr/urn' });
 ```
 
 ## Documentation
@@ -44,6 +42,24 @@ const player = new Pillarbox('my-player', {// Options... });
 For detailed information on how to use the Pillarbox Web Player, checkout
 the [API Documentation](https://srgssr.github.io/pillarbox-web/api). A live demo of the player is
 available here: [Pillarbox Web Demo](https://srgssr.github.io/pillarbox-web-demo/)
+
+## Pillarbox flavours
+
+Pillarbox comes in two variants:
+
+- `pillarbox-core`: is the core library that provides a rich set of features on top of the Video.js
+  API. It does not include any SRGSSR-specific business logic, so it can be used by any developer
+  who wants to customize their own video player.
+- `pillarbox` is the complete package that includes the core library as well as the SRGSSR data
+  provider and analytics. It is designed for SRGSSR applications that need to integrate with the
+  SRGSSR media platform and tracking behavior.
+
+## TypeScript Support
+
+TypeScript is a language that extends JavaScript with static types and other features. It helps to
+write more reliable and maintainable code. `Pillarbox` is written in plain JavaScript, but it
+provides type declarations for TypeScript users. These declarations are carefully generated and
+included in the bundled package.
 
 ## Contributing
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -32,13 +32,20 @@ const player = new Pillarbox('my-player', {// Options... });
 player.src({ src: 'urn:swi:video:48115940', type: 'srgssr/urn' });
 ```
 
+## Player workflows
+
+For a comprehensive guide on player workflows, refer to the
+official [Video.js Player Workflows Guide](https://videojs.com/guides/player-workflows/). More
+showcases and examples ara available in
+the [Pillarbox Demo Application](https://srgssr.github.io/pillarbox-web-demo/showcase).
 
 ## Further Reading
 
-The most useful doc tu start is the [Player](./Player.html) class.
+Pillarbox serves as a superset of video.js, making all the available API features from video.js
+accessible without any modification. The most useful doc tu start is the [Player](./Player.html)
+class.
 
-To learn more about Pillarbox, you can check out
-our [Demo Application](https://srgssr.github.io/pillarbox-web/showcase). To learn more about
-video.js, you can visit the [Video.js Guides](https://videojs.com/guides) and
-the [API docs](https://docs.videojs.com/). Keep track of
-our [Known Issues](./tutorial-Known%20Issues.html) section.
+To learn more about video.js, you can visit the [Video.js Guides](https://videojs.com/guides) and
+the [Video.js API docs](https://docs.videojs.com/).
+
+Keep track of our [Known Issues](./tutorial-Known%20Issues.html) section.

--- a/docs/api/tutorials/Supported Media Types.md
+++ b/docs/api/tutorials/Supported Media Types.md
@@ -1,0 +1,35 @@
+Pillarbox's ability to decode and play specific media formats relies on the browser's built-in
+capabilities. Codec support can vary among different browsers.
+
+To delve deeper into how codecs work and to check the most up-to-date information, you can refer to
+the following online resources:
+
+- [Video.js HTML5 Video Support][html5-video-support] - A comprehensive overview of HTML5 codec
+  support by browser.
+- [MSDN Working with media in HTML5][msdn-html5-media] - Also provides insights into supported media
+  formats in HTML5.
+- [Video Codecs - MDN Web Docs][mdn-video-codecs] - In-depth explanation of video codecs and their
+  usage in browsers.
+
+### Adaptive Streaming Support
+
+Adaptive streaming refers to the dynamic adjustment of bandwidth and, usually, the quality of a
+media stream in real-time, responding to the user's available bandwidth.
+
+Pillarbox supports adaptive media streaming by harnessing the capabilities of
+the [videojs/http-streaming][videojs-http-streaming] library. Refer to the
+following [Compatibility Chart][compatibility-chart] for a breakdown of compatibility with various
+browsers; consider checking the library's documentation for the latest information.
+
+### DRM Support
+
+Pillarbox provides Digital Rights Management (DRM) support via
+the [videojs/videojs-contrib-eme][videojs-contrib-eme] library. Consider checking the library's
+documentation for the latest information.
+
+[html5-video-support]: https://videojs.com/html5-video-support/
+[msdn-html5-media]: https://learn.microsoft.com/en-us/archive/msdn-magazine/2011/november/html5-working-with-media-in-html5#supported-media-formats-in-html5
+[mdn-video-codecs]: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs
+[videojs-http-streaming]: https://github.com/videojs/http-streaming
+[compatibility-chart]: https://github.com/videojs/http-streaming/tree/main?tab=readme-ov-file#compatibility
+[videojs-contrib-eme]: https://github.com/videojs/videojs-contrib-eme


### PR DESCRIPTION
## Description

Transfers all existing wiki articles to the newly created JSDoc site. This revision consolidates all documentation onto a single platform, enabling association with specific library versions.