### PR TITLE
fix: typings and css generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "module": "dist/pillarbox.es.js",
   "style": "./dist/pillarbox.min.css",
-  "types": "./dist/types/pillarbox.d.ts",
+  "types": "./dist/types/build.es.d.ts",
   "files": [
     "dist/*",
     "scss/*"

--- a/scss/pillarbox.scss
+++ b/scss/pillarbox.scss
@@ -1,4 +1,4 @@
-@import '../node_modules/video.js/dist/video-js.css';
+@import '../node_modules/video.js/dist/video-js';
 
 /*
 ******************************************************************************

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
    *
    * Usage: npx -p typescript tsc
    */
-  "include": ["src/**/*"],
+  "include": ["build.es.js"],
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,


### PR DESCRIPTION
## Description

Resolves #202 by removing the `.css` suffix from the Video.js import statement in the Pillarbox theme. The Video.js CSS is now correctly bundled with the Pillarbox theme.

Resolves #205 by exporting the `Player` class on the main entry point of the generated typings. This change allows the Pillarbox custom player to be accessible.

## Changes made

- Removed `css` suffix from the Video.js import statement in the Pillarbox theme.
- Generated the typings directly from `build.es.js` instead of `src/**/*`.
- Changed the `package.json` default `types` export to `dist/types/build.es.d.ts`.
