### PR TITLE
feat: handle chapters, block segments, time intervals, remote text tracks

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,11 @@
         src: 'urn:rts:video:10894383',
         type: 'srgssr/urn'
       },
+      _closingCredits: {
+        label: 'Closing credits at 2620 (43:40)',
+        src: 'urn:rts:video:14683290',
+        type: 'srgssr/urn'
+      },
     };
 
     // Expose Pillarbox and player in the window object for debugging

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     const ilHost = searchParams.get("ilHost") || undefined;
     const language = searchParams.get("language");
     const resize = searchParams.has("resize");
-    const urn = searchParams.get("urn") || "urn:swi:video:48115940";
+    const urn = searchParams.get("urn") || "urn:swi:video:48864812";
 
     // Expose Pillarbox and player in the window object for debugging
     window.pillarbox = Pillarbox;

--- a/index.html
+++ b/index.html
@@ -34,6 +34,15 @@
     const resize = searchParams.has("resize");
     const urn = searchParams.get("urn") || "urn:swi:video:48864812";
 
+    // Media examples
+    window.mediaExamples = {
+      _blockedSegmentAndChapters: {
+        label: 'Blocked segment at 761 (12:42) and chapters',
+        src: 'urn:rts:video:10894383',
+        type: 'srgssr/urn'
+      },
+    };
+
     // Expose Pillarbox and player in the window object for debugging
     window.pillarbox = Pillarbox;
 

--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -138,6 +138,15 @@ class MediaComposition {
   }
 
   /**
+   * Get blocked segments from the main chapter.
+   *
+   * @returns {Array} of blocked segments
+   */
+  getMainBlockedSegments() {
+    return this.getMainSegments().filter(segment => segment.blockReason);
+  }
+
+  /**
    * Get the mediaComposition's main chapter.
    *
    * @returns {Object}
@@ -187,6 +196,7 @@ class MediaComposition {
         resource.analyticsMetadata
       ),
       blockReason: this.getMainChapter().blockReason,
+      blockedSegments: this.getMainBlockedSegments(),
       chapters: this.getChapters(),
       vendor: this.getMainChapter().vendor,
       drmList: resource.drmList,

--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -202,6 +202,7 @@ class MediaComposition {
       streaming: resource.streaming,
       streamOffset: resource.streamOffset,
       subtitles: this.getFilteredExternalSubtitles(),
+      intervals: this.getMainTimeIntervals(),
       tokenType: resource.tokenType,
       url: resource.url,
       urn: this.chapterUrn
@@ -221,6 +222,19 @@ class MediaComposition {
     }
 
     return this.mainSegments || [];
+  }
+
+  /**
+   * Get time intervals from the main chapter.
+   *
+   * @returns {Array} of time intervals
+   */
+  getMainTimeIntervals() {
+    const {
+      timeIntervalList = []
+    } = this.getMainChapter() || {};
+
+    return timeIntervalList;
   }
 
   /**

--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -202,6 +202,7 @@ class MediaComposition {
       streamOffset: resource.streamOffset,
       tokenType: resource.tokenType,
       url: resource.url,
+      urn: this.chapterUrn
     }));
   }
 

--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -187,6 +187,7 @@ class MediaComposition {
         resource.analyticsMetadata
       ),
       blockReason: this.getMainChapter().blockReason,
+      chapters: this.getChapters(),
       vendor: this.getMainChapter().vendor,
       drmList: resource.drmList,
       dvr: resource.dvr,

--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -200,6 +200,7 @@ class MediaComposition {
       quality: resource.quality,
       streaming: resource.streaming,
       streamOffset: resource.streamOffset,
+      subtitles: this.getFilteredExternalSubtitles(),
       tokenType: resource.tokenType,
       url: resource.url,
       urn: this.chapterUrn

--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -17,6 +17,30 @@ import '../lang/rm.js';
  */
 class SrgSsr {
   /**
+   * Adds remote text tracks from an array of subtitles.
+   *
+   * @param {import('video.js/dist/types/player').default} player
+   * @param {Array} [subtitles=[]]
+   */
+  static addRemoteTextTracks(player, subtitles = []) {
+    if (!Array.isArray(subtitles)) return;
+
+    subtitles.forEach(({
+      type,
+      language: label,
+      locale: language,
+      url: src
+    }) => {
+      player.addRemoteTextTrack({
+        kind: type === 'SDH' ? 'captions' : 'subtitles',
+        label,
+        language,
+        src
+      });
+    });
+  }
+
+  /**
    * Set a blocking reason according to the block reason returned
    * by mediaData.
    *
@@ -305,6 +329,8 @@ class SrgSsr {
 
           if (SrgSsr.blockingReason(player, mediaData.blockReason, srcMediaObj))
             return;
+
+          SrgSsr.addRemoteTextTracks(player, mediaData.subtitles);
 
           return next(null, srcMediaObj);
         } catch (error) {

--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -77,6 +77,39 @@ class SrgSsr {
   }
 
   /**
+   * Adds intervals to the player.
+   *
+   * @param {import('video.js/dist/types/player').default} player
+   * @param {Array} [intervals=[]]
+   */
+  static addIntervals(player, intervals = []) {
+    const trackId = 'srgssr-intervals';
+    const removeTrack = player.textTracks().getTrackById(trackId);
+
+    if (removeTrack) {
+      player.textTracks().removeTrack(removeTrack);
+    }
+
+    if (!Array.isArray(intervals) || !intervals.length) return;
+
+    const intervalTrack = new Pillarbox.TextTrack({
+      tech: player.tech(true),
+      kind: 'metadata',
+      id: trackId
+    });
+
+    intervals.forEach(interval => {
+      intervalTrack.addCue({
+        startTime: interval.markIn / 1_000,
+        endTime: interval.markOut / 1_000,
+        text: JSON.stringify(interval)
+      });
+    });
+
+    player.textTracks().addTrack(intervalTrack);
+  }
+
+  /**
    * Set a blocking reason according to the block reason returned
    * by mediaData.
    *
@@ -368,6 +401,7 @@ class SrgSsr {
 
           SrgSsr.addRemoteTextTracks(player, mediaData.subtitles);
           SrgSsr.addChapters(player, mediaData.urn, mediaData.chapters);
+          SrgSsr.addIntervals(player, mediaData.intervals);
 
           return next(null, srcMediaObj);
         } catch (error) {

--- a/test/dataProvider/model/MediaComposition.spec.js
+++ b/test/dataProvider/model/MediaComposition.spec.js
@@ -517,6 +517,7 @@ describe('MediaComposition', () => {
       expect(resource).toHaveProperty('quality');
       expect(resource).toHaveProperty('streaming');
       expect(resource).toHaveProperty('streamOffset');
+      expect(resource).toHaveProperty('subtitles');
       expect(resource).toHaveProperty('tokenType');
       expect(resource).toHaveProperty('url');
       expect(resource).toHaveProperty('urn');

--- a/test/dataProvider/model/MediaComposition.spec.js
+++ b/test/dataProvider/model/MediaComposition.spec.js
@@ -504,6 +504,7 @@ describe('MediaComposition', () => {
 
       expect(resource).toHaveProperty('analyticsData');
       expect(resource).toHaveProperty('analyticsMetadata');
+      expect(resource).toHaveProperty('chapters');
       expect(resource).toHaveProperty('vendor');
       expect(resource).toHaveProperty('dvr');
       expect(resource).toHaveProperty('drmList');

--- a/test/dataProvider/model/MediaComposition.spec.js
+++ b/test/dataProvider/model/MediaComposition.spec.js
@@ -22,6 +22,7 @@ import * as urnInternalSubtitles from '../../__mocks__/urn:srf:only:internal:sub
 import * as urnMultipleExternalSubtitles from '../../__mocks__/urn:swi:multiple:external:subtitles.json';
 import * as urnMixedInternalExternalSubtitles from '../../__mocks__/urn:mixed:internal:external:subtitles.json';
 import * as urnUndefinedResourcelist from '../../__mocks__/urn:undefined:resourcelist.json';
+import * as urnTimeIntervalList from '../../__mocks__/urn:rts:video:10313496-credits.json';
 
 describe('MediaComposition', () => {
   const mediaCompositionUrnAnalyticsData = Object.assign(
@@ -148,6 +149,11 @@ describe('MediaComposition', () => {
   const mediaCompositionUrnUndefinedResourcelist = Object.assign(
     new MediaComposition(),
     urnUndefinedResourcelist
+  );
+
+  const mediaCompositionUrnTimeIntervalList = Object.assign(
+    new MediaComposition(),
+    urnTimeIntervalList
   );
 
   const DRMLIST = {
@@ -511,6 +517,7 @@ describe('MediaComposition', () => {
       expect(resource).toHaveProperty('eventData');
       expect(resource).toHaveProperty('id');
       expect(resource).toHaveProperty('imageCopyright');
+      expect(resource).toHaveProperty('intervals');
       expect(resource).toHaveProperty('live');
       expect(resource).toHaveProperty('mediaType');
       expect(resource).toHaveProperty('mimeType');
@@ -611,6 +618,39 @@ describe('MediaComposition', () => {
     it('should return an empty array when segmentList is undefined', () => {
       expect(mediaCompositionUrnChapterBadOrder.getMainSegments()).toBeTruthy();
       expect(mediaCompositionUrnChapterBadOrder.getMainSegments()).toHaveLength(
+        0
+      );
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * getMainTimeIntervals ******************************************************
+   *****************************************************************************
+   */
+  describe('getMainTimeIntervals', ()=> {
+    it('should return all time intervals', () => {
+      const jsonIntervals = mediaCompositionUrnTimeIntervalList.chapterList[0].timeIntervalList;
+      const intervals = mediaCompositionUrnTimeIntervalList.getMainTimeIntervals();
+
+      expect(intervals).toBeTruthy();
+      expect(intervals).toHaveLength(2);
+      expect(intervals).toEqual(expect.arrayContaining(jsonIntervals));
+      expect(mediaCompositionUrnTimeIntervalList.getMainTimeIntervals()).toEqual(
+        jsonIntervals
+      );
+    });
+
+    it('should return an empty array when timeIntervalList is undefined', () => {
+      expect(mediaCompositionUrnOnlyOneChapter.getMainTimeIntervals()).toBeTruthy();
+      expect(mediaCompositionUrnOnlyOneChapter.getMainTimeIntervals()).toHaveLength(
+        0
+      );
+    });
+
+    it('should return an empty array when the mediaComposition does not have a main chapter', () => {
+      expect(mediaCompositionUrnEmptyChapters.getMainTimeIntervals()).toBeTruthy();
+      expect(mediaCompositionUrnEmptyChapters.getMainTimeIntervals()).toHaveLength(
         0
       );
     });

--- a/test/dataProvider/model/MediaComposition.spec.js
+++ b/test/dataProvider/model/MediaComposition.spec.js
@@ -519,6 +519,7 @@ describe('MediaComposition', () => {
       expect(resource).toHaveProperty('streamOffset');
       expect(resource).toHaveProperty('tokenType');
       expect(resource).toHaveProperty('url');
+      expect(resource).toHaveProperty('urn');
     });
 
     it('should return the main resources for an on demand video', () => {

--- a/test/dataProvider/model/MediaComposition.spec.js
+++ b/test/dataProvider/model/MediaComposition.spec.js
@@ -510,6 +510,7 @@ describe('MediaComposition', () => {
 
       expect(resource).toHaveProperty('analyticsData');
       expect(resource).toHaveProperty('analyticsMetadata');
+      expect(resource).toHaveProperty('blockedSegments');
       expect(resource).toHaveProperty('chapters');
       expect(resource).toHaveProperty('vendor');
       expect(resource).toHaveProperty('dvr');

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -185,6 +185,10 @@ describe('SrgSsr', () => {
       }]);
 
       expect(result).toHaveLength(2);
+      expect(result[0].startTime).toBe(2.5);
+      expect(result[0].endTime).toBe(5);
+      expect(result[1].startTime).toBe(6);
+      expect(result[1].endTime).toBe(9.5);
     });
   });
 
@@ -233,6 +237,8 @@ describe('SrgSsr', () => {
       }]);
 
       expect(result).toHaveLength(2);
+      expect(JSON.parse(result[0].text).type).toBe('OPENING_CREDITS');
+      expect(JSON.parse(result[1].text).type).toBe('CLOSING_CREDITS');
     });
   });
 

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -121,6 +121,54 @@ describe('SrgSsr', () => {
 
   /**
    *****************************************************************************
+   * addIntervals **************************************************************
+   *****************************************************************************
+   */
+  describe('addIntervals', () => {
+    it('should not create an interval track if the intervals parameter is not an array or if the array is empty', async () => {
+      const spyOnPillarboxTextTrack = jest.spyOn(Pillarbox, 'TextTrack');
+
+      SrgSsr.addIntervals(player, true);
+      SrgSsr.addIntervals(player, null);
+      SrgSsr.addIntervals(player, '');
+      SrgSsr.addIntervals(player, undefined);
+
+      expect(spyOnPillarboxTextTrack).not.toHaveBeenCalled();
+    });
+
+    it('should remove intervals track if any', async () => {
+      const spyOnRemoveTrack = jest.spyOn(player.textTracks(), 'removeTrack');
+
+      player.textTracks().getTrackById.mockReturnValueOnce({});
+      SrgSsr.addIntervals(player);
+
+      expect(spyOnRemoveTrack).toHaveBeenCalled();
+    });
+
+    it('should add intervals to the player', async () => {
+      const result = [];
+
+      Pillarbox.TextTrack
+        .prototype
+        .addCue
+        .mockImplementation((cue) => result.push(cue));
+
+      SrgSsr.addIntervals(player, [{
+        markIn: 1_000,
+        markOut: 2_000,
+        type: 'OPENING_CREDITS'
+      }, {
+        markIn: 10_000,
+        markOut: 15_000,
+        type: 'CLOSING_CREDITS'
+      }]);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  /**
+   *****************************************************************************
    * addRemoteTextTracks *******************************************************
    *****************************************************************************
    */

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -33,6 +33,7 @@ describe('SrgSsr', () => {
     Image.scale = jest.fn(({ url }) => `https://mock-scale.ch/${url}`);
 
     player = {
+      addRemoteTextTrack: jest.fn(),
       debug: jest.fn(),
       error: jest.fn(),
       localize: jest.fn(),
@@ -45,6 +46,60 @@ describe('SrgSsr', () => {
         update: ({ title, description }) => ({ title, description }),
       },
     };
+  });
+
+  /**
+   *****************************************************************************
+   * addRemoteTextTracks *******************************************************
+   *****************************************************************************
+   */
+  describe('addRemoteTextTracks', () => {
+    it('should not call addRemoteTextTracks if subtitles variable is not an array or if the array is empty', async () => {
+      const spyOnAddRemoteTextTracks = jest.spyOn(player, 'addRemoteTextTrack');
+
+      SrgSsr.addRemoteTextTracks(player, true);
+      SrgSsr.addRemoteTextTracks(player, null);
+      SrgSsr.addRemoteTextTracks(player, '');
+      SrgSsr.addRemoteTextTracks(player, undefined);
+
+      expect(spyOnAddRemoteTextTracks).not.toHaveBeenCalled();
+    });
+
+    it('should add a captions-type text track', async () => {
+      const spyOnAddRemoteTextTracks = jest.spyOn(player, 'addRemoteTextTrack');
+
+      SrgSsr.addRemoteTextTracks(player, [{
+        type: 'SDH',
+        language: 'English',
+        locale: 'EN',
+        url: 'https://url.com/en.vtt'
+      }]);
+
+      expect(spyOnAddRemoteTextTracks).toHaveBeenCalledWith({
+        kind: 'captions',
+        label: 'English',
+        language: 'EN',
+        src: 'https://url.com/en.vtt'
+      });
+    });
+
+    it('should add a subtitles text track if the type is different from SDH', async () => {
+      const spyOnAddRemoteTextTracks = jest.spyOn(player, 'addRemoteTextTrack');
+
+      SrgSsr.addRemoteTextTracks(player, [{
+        type: 'something-else',
+        language: 'English',
+        locale: 'EN',
+        url: 'https://url.com/en.vtt'
+      }]);
+
+      expect(spyOnAddRemoteTextTracks).toHaveBeenCalledWith({
+        kind: 'subtitles',
+        label: 'English',
+        language: 'EN',
+        src: 'https://url.com/en.vtt'
+      });
+    });
   });
 
   /**


### PR DESCRIPTION
## Description

This PR adds support for blocked segments, chapters, intervals and remote text tracks.

To allow developers to create their own experience, metadata text tracks are used. This type of text track has the advantage of not being displayed on screen, however, it is possible to listen to cue change events and react to them as required.

### Usage and definition

#### Blocked segments

Blocked segments are portions of content that must not be played for various reasons, such as legal, geo-blocking, etc. Resolves #211

```javascript
// Accessing raw data
player.currentSource().mediaData.blockedSegments;

// Listen for cuechange events and get the active cue
player.textTracks().getTrackById('srgssr-blocked-segments').on('cuechange', ()=>{
        const [active] = Array
  .from(player.textTracks().getTrackById('srgssr-blocked-segments').activeCues);
  JSON.parse(active.text); // note that active can be undefined
});
```

#### Chapters

Chapters are used to define the start and end times of the various subjects comprising a media item. Resolves #204

```javascript
// Accessing raw data
player.currentSource().mediaData.chapters;

// Listen for cuechange events and get the active cue
player.textTracks().getTrackById('srgssr-chapters').on('cuechange', ()=>{
        const [active] = Array.from(player.textTracks().getTrackById('srgssr-chapters').activeCues);
  JSON.parse(active.text); // note that active can be undefined
});
```

### Intervals

Intervals allow you to define the start and end times for the credits of a media item. Resolves #212

```javascript
// Accessing raw data
player.currentSource().mediaData.intervals;

// Listen for cuechange events and get the active cue
player.textTracks().getTrackById('srgssr-intervals').on('cuechange', ()=>{
        const [active] = Array.from(player.textTracks().getTrackById('srgssr-intervals').activeCues);
  JSON.parse(active.text); // note that active can be undefined
});
```

## Changes made

- expose media URN, refer to e0d55375b7ccca387fd24a0a0f1f338c1de9b9f3
- add remote subtitles, resolves #203, refer to bc02149f0a01df653513d9abdd00b6ef915b0b83
- add chapters, refer to 9997a01ff49ed0b72dbcead4f03387d0338a26aa
- add intervals, refer to 84d9ae09a30399d34815f4eada642eebaa5e134b
- add blocked segments, refer to 8ca34a810377e2745b4eca0ddda1f6ce9f7c7fe2
- refactor, refer to 62fa6ca7f9078d7749eeadeb247eae8cbd1205d0
