### PR TITLE
refactor(srgssr-middleware): move srgssr specific options declaration

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -319,4 +319,10 @@ class SrgSsr {
 
 Pillarbox.use('srgssr/urn', SrgSsr.middleware);
 
+// Add Middleware specific options
+Pillarbox.options.srgOptions = {
+  dataProviderHost: undefined,
+  tagCommanderScriptURL: undefined,
+};
+
 export default SrgSsr;

--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -18,6 +18,7 @@ pillarbox.VERSION = {
   [videojs.VhsSourceHandler.name]: videojs.VhsSourceHandler.VERSION,
   eme: videojs.getPlugin('eme').VERSION,
 };
+
 /**
  * Enable smooth seeking for Pillarbox.
  *
@@ -84,11 +85,11 @@ pillarbox.options.plugins = { eme: true };
  * @type {boolean}
  */
 pillarbox.options.responsive = true;
-pillarbox.options.srgOptions = {
-  dataProviderHost: undefined,
-  tagCommanderScriptURL: undefined,
-};
+/**
+ * A placeholder for accessing trackers directly from the player.
+ *
+ * @type {Object}
+ */
 pillarbox.options.trackers = {};
-
 
 export default pillarbox;


### PR DESCRIPTION
## Description

Considering we generate two builds for the library it makes sense to perform the declaration of SRG SSR specific options in the middleware itself. This approach prevents the `core` build from exposing options specific to the SRG SSR business logic and ensures these options are only present when necessary.

## Changes made

- Moved the declaration of SRG SSR specific options from `src/pillarbox.js` to `src/middleware/srgssr.js`.

