### PR TITLE
fix(srgssr-middleware): cuechange event not sent correctly on Safari and Chrome

### DIFF
--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -924,6 +924,8 @@ describe('SrgSsr', () => {
       });
 
       it('should return the blocked segment end time', () => {
+        expect.assertions(3);
+
         const spyOnPlayerCurrentTime = jest.spyOn(player, 'currentTime');
         const middleware = SrgSsr.middleware(player);
         const currentTime = 13;
@@ -934,6 +936,8 @@ describe('SrgSsr', () => {
 
         player.textTracks().getTrackById.mockReturnValueOnce({
           activeCues: [blockedSegmentCue]
+        }).mockReturnValueOnce({
+          trigger: jest.fn().mockImplementationOnce((e)=> expect(e).toBe('cuechange'))
         });
 
         expect(middleware.currentTime(currentTime)).toBe(blockedSegmentCue.endTime);


### PR DESCRIPTION
## Description

The `cuechange` event is not emitted correctly on **Safari** and **Chrome**, when an `activeCue` is available and the current position is updated with the `endTime` value of the active cue.

For example, let's say there's a `metadata` text track that's in charge of automatically skipping certain parts of a content when there's an `activeCue`. Updating the current position with the `endTime` of the `activeCue` inhibits the `cuechange` event.

However, this event may be of interest to a developer who wishes to display a specific message to the user about what has just happened.


## Changes made

- update `handleCurrentTime` to trigger a cuechange event if the browser is not **Firefox**
- remove the capital letter from `Pillarbox`

