### PR TITLE
feat(srgssr-middleware): add custom text tracks cuechange event proxy

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,52 +92,43 @@
       currentTime = undefined;
     });
 
-
-    player.on('loadeddata', () => {
-      const textTracks = player.textTracks();
-
-      // Listen to chapters
-      textTracks.getTrackById('srgssr-chapters').addEventListener('cuechange', () => {
-        const [cue] = Array.from(textTracks.getTrackById('srgssr-chapters').activeCues);
-
-        if (!cue) {
-          // Reset media title when no longer in a chapter
-          player.titleBar.update({
-            title: player.currentSource().mediaData.vendor,
-            description: player.currentSource().mediaData.title
-          });
-
-          return;
-        };
-
-        const chapter = JSON.parse(cue.text);
-
-        // Update the title bar with the current chapter
+    // Listen blocked segments, chapters and intervals
+    player.on(['srgssr/blocked-segment', 'srgssr/chapter', 'srgssr/interval'], ({ type, data }) => {
+      // Title bar reset when outside a chapter
+      if ('srgssr/chapter' === type && !data) {
         player.titleBar.update({
-          title: chapter.title,
-          description: chapter.description
+          title: player.currentSource().mediaData.vendor,
+          description: player.currentSource().mediaData.title
         });
 
-        console.log('%cChapter', 'background-color: blue', chapter.title);
-      });
+        return;
+      }
 
-      // Listen to blocked segment
-      textTracks.getTrackById('srgssr-blocked-segments')?.on('cuechange', () => {
-        const [cue] = Array.from(textTracks.getTrackById('srgssr-blocked-segments')?.activeCues);
+      if (!data) return;
 
-        if (!cue) return;
+      const cueContent = JSON.parse(data.text);
 
-        console.log('%cBlock reason', 'background-color: red', JSON.parse(cue.text).blockReason);
-      });
+      // Blocked segment
+      if ('srgssr/blocked-segment' === type) {
 
-      // Listen to intervals
-      textTracks.getTrackById('srgssr-intervals')?.addEventListener('cuechange', () => {
-        const [cue] = Array.from(textTracks.getTrackById('srgssr-intervals')?.activeCues);
+        console.log('%cBlock reason', 'background-color: red', cueContent.blockReason);
+        return;
+      }
 
-        if (!cue) return;
+      // Chapter
+      if ('srgssr/chapter' === type) {
+        // Update the title bar with the current chapter
+        player.titleBar.update({
+          title: cueContent.title,
+          description: cueContent.description
+        });
 
-        console.log('%cInterval', 'background-color: green', JSON.parse(cue.text).type);
-      });
+        console.log('%cChapter', 'background-color: blue', cueContent.title);
+        return;
+      }
+
+      // Interval
+      console.log('%cInterval', 'background-color: green', cueContent.type);
     });
 
     player.src({

--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -280,6 +280,24 @@ class SrgSsr {
   }
 
   /**
+   * Proxy SRG SSR chapters and intervals cuechange events at player level.
+   *
+   * @param {import('video.js/dist/types/player').default} player
+   */
+  static cuechangeEventProxy(player) {
+    player.textTracks().on('addtrack', ({ track }) => {
+      if (!['srgssr-chapters', 'srgssr-intervals'].includes(track.id)) return;
+
+      track.on('cuechange', () => {
+        const [cue] = Array.from(track.activeCues);
+        const type = track.id.includes('srgssr-chapters') ? 'srgssr/chapter' : 'srgssr/interval';
+
+        player.trigger({ type, data: cue });
+      });
+    });
+  }
+
+  /**
    * SRG SSR data provider singleton.
    *
    * @param {import('video.js/dist/types/player').default} player
@@ -379,14 +397,14 @@ class SrgSsr {
   }
 
   /**
-   * Get the end time of a blocked segment.
+   * Get the VTT cue of a blocked segment.
    *
    * @param {import('video.js/dist/types/player').default} player
    * @param {Number} currentTime
    *
-   * @returns {Number|undefined} The end time of a blocked segment, or undefined
+   * @returns {VTTCue|undefined} The VTT cue of a blocked segment, or undefined
    */
-  static getBlockedSegmentEndTime(player, currentTime) {
+  static getBlockedSegmentByTime(player, currentTime) {
     const blockedSegment = SrgSsr.getBlockedSegment(player);
 
     if (!blockedSegment) return;
@@ -394,7 +412,7 @@ class SrgSsr {
     const isBlocked = currentTime >= blockedSegment.startTime &&
       currentTime < blockedSegment.endTime;
 
-    return isBlocked ? blockedSegment.endTime : undefined;
+    return isBlocked ? blockedSegment : undefined;
   }
 
   /**
@@ -461,16 +479,18 @@ class SrgSsr {
    * @returns {number}
    */
   static handleCurrentTime(player, currentTime) {
-    const blockedSegmentEndTime = SrgSsr
-      .getBlockedSegmentEndTime(player, currentTime);
+    const blockedSegment = SrgSsr
+      .getBlockedSegmentByTime(player, currentTime);
 
-    if (Number.isFinite(blockedSegmentEndTime)) {
-      player.currentTime(blockedSegmentEndTime);
-
-      return blockedSegmentEndTime;
+    if (!blockedSegment || !Number.isFinite(blockedSegment.endTime)) {
+      return currentTime;
     }
 
-    return currentTime;
+    // proxy for handling cuechange events at the player level
+    player.trigger({ type: 'srgssr/blocked-segment', data: blockedSegment });
+    player.currentTime(blockedSegment.endTime);
+
+    return blockedSegment.endTime;
   }
 
   /**
@@ -487,8 +507,8 @@ class SrgSsr {
    * @returns {number}
    */
   static handleSetCurrentTime(player, currentTime) {
-    const blockedSegmentEndTime = SrgSsr
-      .getBlockedSegmentEndTime(player, currentTime);
+    const { endTime: blockedSegmentEndTime } = SrgSsr
+      .getBlockedSegmentByTime(player, currentTime) || {};
 
     return Number
       .isFinite(blockedSegmentEndTime) ? blockedSegmentEndTime : currentTime;
@@ -592,6 +612,9 @@ class SrgSsr {
    * @returns {Object}
    */
   static middleware(player) {
+
+    SrgSsr.cuechangeEventProxy(player);
+
     return {
       currentTime: (currentTime) =>
         SrgSsr.handleCurrentTime(player, currentTime),


### PR DESCRIPTION
## Description

This new feature allows to listen to events linked to chapters, intervals and blocked segments directly from the player. This eliminates the need to check that text tracks are loaded correctly, in order to avoid errors.

These events will contain a `data` property whose value will be the `VTTCue` when entering the cue or `undefined` when leaving it. This is valid for chapters and intervals, however the exit of a blocked segment is not notified, since it occurs instantaneously.

**Added events:**
- `srgssr/blocked-segment`
- `srgssr/chapter`
- `srgssr/interval`

**Usage:**

```javascript
// Listen to an event
player.on('srgssr/blocked-segment', ({ type, data }) => {
  // do something
});
// Listen to multiple events at the same time
player.on([
  'srgssr/blocked-segment',
  'srgssr/chapter',
  'srgssr/interval'
  ], ({ type, data }) => {
  // do something
});
```

## Changes made

- add a new function to proxy with `cuechange`
- modify handleCurrentTime to manually launch the blocked segment event. This avoids inconsistencies in cuechange sending on Safari and Chrome.
- renamed the getBlockedSegmentEndTime function, which now returns a marker
- modified handleSetCurrentTime to extract the end time of a blocked segment from the benchmark
- update the development page
- added and updated unit tests

