### PR TITLE
feat: modify default options

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,6 @@
     window.player = new pillarbox('player', {
       audioOnlyMode,
       debug,
-      fill: true,
       language,
       srgOptions: {
         dataProviderHost: ilHost

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -1,4 +1,5 @@
 import videojs from 'video.js';
+import 'videojs-contrib-eme';
 
 /**
  * @ignore
@@ -13,6 +14,18 @@ const vjsPlayer = videojs.getComponent('player');
  * @see https://docs.videojs.com/player
  */
 class Player extends vjsPlayer {
+  constructor(tag, options, ready) {
+    /**
+     * Configuration for plugins.
+     *
+     * @see [Video.js Plugins Option]{@link https://videojs.com/guides/options/#plugins}
+     * @type {Object}
+     * @property {boolean} eme - Enable the EME (Encrypted Media Extensions) plugin.
+     */
+    options = videojs.obj.merge(options, { plugins: { eme: true }});
+    super(tag, options, ready);
+  }
+
   /**
    * A getter/setter for the media's audio track.
    * Activates the audio track according to the language and kind properties.

--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -1,6 +1,5 @@
 import { version } from '../package.json';
 import videojs from 'video.js';
-import 'videojs-contrib-eme';
 import './components/player.js';
 
 /**
@@ -27,6 +26,14 @@ pillarbox.VERSION = {
  * @default true
  */
 pillarbox.options.enableSmoothSeeking = true;
+/**
+ * Enable fill mode for the video player, allowing it to expand to fill the container.
+ *
+ * @see [Video.js Fill Option]{@link https://videojs.com/guides/layout/#fill-mode}
+ * @type {boolean}
+ * @default true
+ */
+pillarbox.options.fill = true;
 /**
  * Configuration options for HTML5 settings in Pillarbox.
  *
@@ -70,14 +77,6 @@ pillarbox.options.liveui = true;
  * @type {boolean}
  */
 pillarbox.options.playsinline = true;
-/**
- * Configuration for plugins.
- *
- * @see [Video.js Plugins Option]{@link https://videojs.com/guides/options/#plugins}
- * @type {Object}
- * @property {boolean} eme - Enable the EME (Encrypted Media Extensions) plugin.
- */
-pillarbox.options.plugins = { eme: true };
 /**
  * Enable responsive mode, this will cause the player to customize itself based on responsive breakpoints.
  *

--- a/test/components/player.spec.js
+++ b/test/components/player.spec.js
@@ -121,4 +121,15 @@ describe('Player', () => {
       expect(player.textTracks.mock.results[0].value[1].mode).toBe('disabled');
     });
   });
+
+  describe('eme', () => {
+    const player = new Player(videoEl);
+
+    it('should have initialize eme plugin', () => {
+      expect(player.eme).toBeDefined();
+      // When a plugin is initialized its function becomes an object
+      expect(typeof player.eme).not.toBe('function');
+      expect(typeof player.eme).toBe('object');
+    });
+  });
 });

--- a/test/pillarbox.spec.js
+++ b/test/pillarbox.spec.js
@@ -42,8 +42,8 @@ describe('Pillarbox', () => {
       expect(pillarbox.options.playsinline).toBe(true);
     });
 
-    it('should have plugins configuration with EME set to true by default', () => {
-      expect(pillarbox.options.plugins).toEqual({ eme: true });
+    it('should have fill set to true by default', () => {
+      expect(pillarbox.options.fill).toBe(true);
     });
 
     it('should have responsive set to true by default', () => {


### PR DESCRIPTION
## Description

This pull request addresses 2 issues with the default options:

1. The `eme` plugin is not loaded by default in the following manner:
    ```javascript
    videojs.options.plugins = { eme: true };
    ```
    To address this limitation, this change 

2. Integrators must explicitly set the `fill` option to `true` even though this commonly expected behaviour.

## Changes made

- Modifies the player constructor to automatically set the `eme` plugin option to true, ensuring its activation by default.
- Moved the import of `videojs-contrib-eme` to the player component.
- Activates the fill option by default.