### PR TITLE
fix(srgssr-middleware): safari stalls at end of blocked segment

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -486,11 +486,15 @@ class SrgSsr {
       return currentTime;
     }
 
+    // as a workaround, add 0.1 seconds to avoid getting stuck on endTime on
+    // some safaris.
+    const endTimeWithTolerance = blockedSegment.endTime + 0.1;
+
     // proxy for handling cuechange events at the player level
     player.trigger({ type: 'srgssr/blocked-segment', data: blockedSegment });
-    player.currentTime(blockedSegment.endTime);
+    player.currentTime(endTimeWithTolerance);
 
-    return blockedSegment.endTime;
+    return endTimeWithTolerance;
   }
 
   /**
@@ -563,7 +567,7 @@ class SrgSsr {
         debug: player.debug(),
         playerVersion: Pillarbox.VERSION.pillarbox,
         tagCommanderScriptURL:
-        player.options().srgOptions.tagCommanderScriptURL,
+          player.options().srgOptions.tagCommanderScriptURL,
       });
 
       player.options({

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -907,6 +907,16 @@ describe('SrgSsr', () => {
 
       expect(spyOnOptions).toHaveBeenLastCalledWith(expect.objectContaining({ trackers: { srgAnalytics: expect.any(Object) }}));
     });
+
+    it('should not reinitialize the srgAnalytics', () => {
+      player.options().trackers.srgAnalytics = {};
+
+      const spyOnOptions = jest.spyOn(player, 'options');
+
+      SrgSsr.srgAnalytics(player);
+
+      expect(spyOnOptions).not.toHaveBeenLastCalledWith(expect.objectContaining({ trackers: { srgAnalytics: expect.any(Object) }}));
+    });
   });
 
   /**
@@ -1018,7 +1028,7 @@ describe('SrgSsr', () => {
         expect(middleware.currentTime(currentTime)).toBe(currentTime);
       });
 
-      it('should return the blocked segment end time', () => {
+      it('should return the blocked segment end time with a 0.1 second tolerance', () => {
         const spyOnPlayerCurrentTime = jest.spyOn(player, 'currentTime');
         const spyOnPlayerTrigger = jest.spyOn(player, 'trigger');
         const middleware = SrgSsr.middleware(player);
@@ -1028,13 +1038,14 @@ describe('SrgSsr', () => {
           endTime: 20,
           text: JSON.stringify('data')
         };
+        const endTimeWithTolerance = blockedSegmentCue.endTime + 0.1;
 
         player.textTracks().getTrackById.mockReturnValueOnce({
           activeCues: [blockedSegmentCue]
         });
 
-        expect(middleware.currentTime(currentTime)).toBe(blockedSegmentCue.endTime);
-        expect(spyOnPlayerCurrentTime).toHaveBeenCalledWith(blockedSegmentCue.endTime);
+        expect(middleware.currentTime(currentTime)).toBe(endTimeWithTolerance);
+        expect(spyOnPlayerCurrentTime).toHaveBeenCalledWith(endTimeWithTolerance);
         expect(spyOnPlayerTrigger).toHaveBeenCalledWith({ 'data': blockedSegmentCue, 'type': 'srgssr/blocked-segment' });
       });
     });


### PR DESCRIPTION
## Description

Adds a `tolerance` to prevent some `Safari` browsers from getting stuck at the `endTime` of a blocked segment.

> [!NOTE]
To maintain a certain consistency in the experience, this tolerance is applied to all browsers.

## Changes made

- add a tolerance of 0.1s `handleCurrentTime`
- update the related test case
- adds a missing test case for `srgAnalytics`