### PR TITLE
fix(control-bar): end value in align-items is not compatible with old Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,12 @@
   <link rel="stylesheet" href="./scss/pillarbox.scss" />
 
   <style>
+    html,
     body {
-      height: 100dvh;
+      height: 100%;
+    }
+
+    body {
       margin: 0;
       overflow: hidden;
     }

--- a/scss/components/_control-bar.scss
+++ b/scss/components/_control-bar.scss
@@ -4,7 +4,7 @@
 ******************************************************************************
 */
 &:not(.vjs-audio-only-mode) .vjs-control-bar {
-  align-items: end;
+  align-items: flex-end;
   height: 6em;
   padding-inline: 1em;
   background: linear-gradient(#000 0%, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 100%);


### PR DESCRIPTION
## Description

The property `align-items` is not compatible with the value `end` on Safari versions less than 15.4.

![Screenshot from 2024-03-15 13-53-16](https://github.com/SRGSSR/pillarbox-web/assets/34163393/78cb4f86-006c-47c4-aaa9-5dfbba253e60)

Changes the `dvh` unit used in the demo, which is not compatible with older browsers.


## Changes made
- change value of `align-items`
- use `%` instead of `dvh` in the demo page
