### PR TITLE
fix(srgssr-middleware): incompatibility of older browsers with nullish coalescing

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -80,8 +80,10 @@ class SrgSsr {
    * } data SRG SSR's cue-like representation
    */
   static addTextTrackCue(textTrack, data) {
-    const startTime = (data.markIn ?? data.fullLengthMarkIn) / 1_000;
-    const endTime = (data.markOut ?? data.fullLengthMarkOut) / 1_000;
+    const startTime = (Number.isFinite(data.markIn)
+      ? data.markIn : data.fullLengthMarkIn) / 1_000;
+    const endTime = (Number.isFinite(data.markOut)
+      ? data.markOut : data.fullLengthMarkOut) / 1_000;
 
     textTrack.addCue(new VTTCue(
       startTime,


### PR DESCRIPTION
## Description

The `??` operator has been removed, as it is not compatible with older browsers. This can be a problem when Pillarbox is used on televisions, for example.

## Changes made

- replace nullish coalescing by a ternary operator
