### PR TITLE
chore(npm): add packge lock to semantic release config file

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -105,6 +105,7 @@
       {
         "assets": [
           "package.json",
+          "package-lock.json",
           "docs/CHANGELOG.md"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"


### PR DESCRIPTION
## Description

When Pillarbox is released, the `version` property of `package-lock.json` is not
 updated.

As a result, the `version` properties of `package.json` and `package-lock.json` are out of sync.

## Changes made

- updates `.releaserc` to add `package-lock.json` to the `@semantic-release/git` module
