### PR TITLE
feat: add url handler

### DIFF
--- a/docs/api/tutorials/Options.md
+++ b/docs/api/tutorials/Options.md
@@ -1,14 +1,16 @@
+## Default Options
+
 Pillarbox deviates from the default configuration provided
 by [Video.js](https://videojs.com/guides/options/) on the following key options:
 
-#### `enableSmoothSeeking=true`
+### `enableSmoothSeeking=true`
 
 This option enables smooth seeking for Pillarbox, which means that the player will not pause or
 stutter when seeking to a different position in the video.
 
 See [Video.js enableSmoothSeeking Option](https://videojs.com/guides/options/#enablesmoothseeking).
 
-#### `fill=true`
+### `fill=true`
 
 This mode allows the player to expand to fill its container.
 
@@ -24,14 +26,14 @@ IDs that are not otherwise covered in the dubbed/localized audio.
 
 See [VHS useForcedSubtitles Option](https://github.com/videojs/http-streaming/blob/main/README.md#useforcedsubtitles).
 
-#### `liveTracker.trackingThreshold=120`
+### `liveTracker.trackingThreshold=120`
 
 This property defines a threshold that controls when the live UI should be shown. The live UI will
 be shown if the live edge is within this number of seconds from the current time.
 
 See [Video.js trackingThreshold Option](https://videojs.com/guides/options/#livetrackertrackingthreshold).
 
-#### `liveTracker.liveTolerance=15`
+### `liveTracker.liveTolerance=15`
 
 This property defines an option that controls how far from the seekable end should be considered
 live playback. The player will consider itself live if the current time is within this number of
@@ -39,7 +41,7 @@ seconds from the live edge.
 
 See [Video.js liveTolerance Option](https://videojs.com/guides/options/#livetrackerlivetolerance).
 
-#### `liveui=true`
+### `liveui=true`
 
 This option allows the player to use the live UI that includes: A progress bar for seeking within
 the live window and a button that can be clicked to seek to the live edge with a circle indicating
@@ -47,14 +49,14 @@ if you are at the live edge or not.
 
 See [Video.js liveui Option](https://videojs.com/guides/options/#liveui).
 
-#### `playsinline=true`
+### `playsinline=true`
 
 This option indicates that the video is to be played "inline", that is within the element's playback
 area. This can be useful for mobile devices, where fullscreen playback may not be desired.
 
 See [Video element playsinline attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#playsinline).
 
-#### `plugins.eme=true`
+### `plugins.eme=true`
 
 This property enables the EME plugin, which allows the player to handle encrypted media content
 using a Content Decryption Module (CDM). The CDM is responsible for decrypting the media and
@@ -63,10 +65,64 @@ enforcing the license policy.
 See [Pillarbox DRM Support](https://github.com/SRGSSR/pillarbox-web/wiki/Supported-Media-Types#drm-support)
 and [Video.js Plugins Option](https://videojs.com/guides/options/#plugins).
 
-#### `responsive=true`
+### `responsive=true`
 
 This option enables responsive mode, which will cause the player to customize itself based on
 responsive breakpoints. This means that the player will adjust its size and layout according to the
 screen size and orientation.
 
 See [Video.js Responsive Option](https://videojs.com/guides/options/#responsive).
+
+## Custom Options
+
+The options in this section complement those of video.js, further customizing the player experience.
+
+### `srgOptions.dataProviderHost`
+
+***Specific to media content from SRG SSR.***
+
+Specifies the host URL for the SRG SSR media content data provider. It is used to define a base URL
+for fetching media content metadata.
+
+#### Usage
+
+```javascript
+const player = pillarbox('player', {
+  srgOptions: {
+    // Defines the alternative host
+    dataProviderHost: 'il-stage.srgssr.ch'
+  }
+});
+
+// Load the source with type 'srgssr/urn'
+player.src({ src: 'my-content-id', type: 'srgssr/urn' });
+```
+
+### `srgOptions.dataProviderUrlHandler`
+
+***Specific to media content from SRG SSR.***
+
+Specifies a custom function to generate URLs for SRG SSR media content queries. The function accepts
+a content identifier and returns a string URL to query the back-end. It enables custom integration
+with various back-end systems while using SRG SSR's media playing capabilities.
+
+#### Usage
+
+```javascript
+const player = pillarbox('player', {
+  srgOptions: {
+    // Defines the custom URL handler
+    dataProviderUrlHandler: (id) => `https://my-domain.com/content/${id}`
+  }
+});
+
+// Load the source with type 'srgssr/urn'
+player.src({ src: 'my-content-id', type: 'srgssr/urn' });
+```
+
+The custom URL handler constructs request URLs based on a content identifier. The returned URL must
+lead to a response conforming to the [Media Composition](./MediaComposition.html) structure to
+ensure proper media playback.
+
+> The absence of a conforming object from the server may lead to unexpected errors, affecting video
+> playback.

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
     const language = searchParams.get('language');
     const resize = searchParams.has('resize');
     const urn = searchParams.get('urn') || 'urn:swi:video:48864812';
+    const urlHandler = searchParams.has('urlHandler') ? url => url : undefined;
 
     // Media examples
     window.mediaExamples = {
@@ -73,7 +74,8 @@
       debug,
       language,
       srgOptions: {
-        dataProviderHost: ilHost
+        dataProviderHost: ilHost,
+        dataProviderUrlHandler: urlHandler,
       }
     });
 

--- a/src/dataProvider/services/DataProvider.js
+++ b/src/dataProvider/services/DataProvider.js
@@ -1,42 +1,62 @@
 import MediaComposition from '../model/MediaComposition.js';
 
 /**
+ * Represents a data provider for constructing URLs and handling requests.
+ * @class
  * @ignore
  */
 class DataProvider {
+  /**
+   * Creates an instance of DataProvider.
+   *
+   * @param {string} [hostName='il.srgssr.ch'] The base host name for constructing URLs
+   */
   constructor(hostName = 'il.srgssr.ch') {
     this.setIlHost(hostName);
   }
 
+  /**
+   * Sets the integration layer host name.
+   *
+   * @param {string} hostName The host name to set
+   */
   setIlHost(hostName) {
     this.baseUrl = `${hostName}/integrationlayer/2.1/`;
   }
 
   /**
-   * Get media composition by URN.
+   * Handles requests by constructing URLs and fetching data.
    *
-   * @param {String} urn URN of the media composition.
-   * @param {Boolean} [onlyChapters=true] Whether to retrieve only chapters or not.
+   * This provides unified error handling, regardless of the urlHandler used.
    *
-   * @returns {Promise<{mediaComposition: MediaComposition}>} Promise that resolves with the `mediaComposition` object.
-   * @throws {Promise<Response>} If the response is not ok.
+   * @param {Function} urlHandler A function that constructs the URL
+   *
+   * @returns {Promise<MediaComposition>} A promise with the fetched data
    */
-  async getMediaCompositionByUrn(urn, onlyChapters = true) {
-    const url = `https://${this.baseUrl}mediaComposition/byUrn/${urn}?onlyChapters=${onlyChapters}&vector=portalplay`;
-    const response = await fetch(url);
+  handleRequest(urlHandler) {
+    return async (urn) => {
+      const url = typeof urlHandler === 'function' ? urlHandler(urn) : this.mediaCompositionUrlHandler(urn);
+      const response = await fetch(url);
 
-    if (!response.ok) {
-      throw response;
-    }
+      if (!response.ok) {
+        throw response;
+      }
 
-    const data = await response.json();
-    const mediaComposition = Object.assign(new MediaComposition(), data, {
-      onlyChapters,
-    });
+      const data = await response.json();
 
-    return {
-      mediaComposition,
+      return Object.assign(new MediaComposition(), data);
     };
+  }
+
+  /**
+   * Gets the media composition URL by URN.
+   *
+   * @param {string} urn The URN for the media composition
+   *
+   * @returns {string} The constructed URL
+   */
+  mediaCompositionUrlHandler(urn) {
+    return `https://${this.baseUrl}mediaComposition/byUrn/${urn}?onlyChapters=true&vector=portalplay`;
   }
 }
 

--- a/test/dataProvider/services/DataProvider.spec.js
+++ b/test/dataProvider/services/DataProvider.spec.js
@@ -21,25 +21,25 @@ describe('DataProvider', () => {
 
   /**
    *****************************************************************************
-   * getMediaCompositionByUrn **************************************************
+   * handleRequest *************************************************************
    *****************************************************************************
    */
-  describe('getMediaCompositionByUrn', () => {
+  describe('handleRequest', () => {
     it('should return a mediaComposition object', async () => {
       const spyObject = jest.spyOn(Object, 'assign');
       const mediaComposition =
-        await dataproviderService.getMediaCompositionByUrn(urn10272382);
+        await dataproviderService.handleRequest()(urn10272382);
 
       expect(mediaComposition).toBeTruthy();
       expect(spyObject).toHaveBeenCalled();
     });
 
     it('called multiple times should return a mediaComposition object', async () => {
-      const { mediaComposition: mediaCompositionUrn10272382 } =
-        await dataproviderService.getMediaCompositionByUrn(urn10272382);
+      const mediaCompositionUrn10272382  =
+        await dataproviderService.handleRequest()(urn10272382);
 
-      const { mediaComposition: mediaCompositionUrn8414077 } =
-        await dataproviderService.getMediaCompositionByUrn(urn8414077);
+      const mediaCompositionUrn8414077  =
+        await dataproviderService.handleRequest()(urn8414077);
 
       expect(mediaCompositionUrn10272382).toBeTruthy();
       expect(mediaCompositionUrn10272382.chapterUrn).toEqual(urn10272382);
@@ -49,22 +49,23 @@ describe('DataProvider', () => {
     });
 
     it('should be an instance of MediaComposition', async () => {
-      const { mediaComposition: mediaCompositionUrn10272382 } =
-        await dataproviderService.getMediaCompositionByUrn(urn10272382);
+      const  mediaCompositionUrn10272382  =
+        await dataproviderService.handleRequest()(urn10272382);
 
       expect(mediaCompositionUrn10272382).toBeInstanceOf(MediaComposition);
     });
 
-    it('should set the param onlyChapters to false', async () => {
-      const { mediaComposition: mediaCompositionUrn10272382 } =
-        await dataproviderService.getMediaCompositionByUrn(urn10272382, false);
+    it('should use a custom URL handler', async () => {
+      const customUrlHandler = (urn)=> urn;
+      const  mediaCompositionUrn10272382  =
+        await dataproviderService.handleRequest(customUrlHandler)(urn10272382);
 
-      expect(mediaCompositionUrn10272382.onlyChapters).toBe(false);
+      expect(mediaCompositionUrn10272382).toBeInstanceOf(MediaComposition);
     });
 
     it('should be rejected if URN does not exist', async () => {
       await expect(
-        dataproviderService.getMediaCompositionByUrn(urnNotFound)
+        dataproviderService.handleRequest()(urnNotFound)
       ).rejects.not.toBeNull();
     });
   });


### PR DESCRIPTION
## Description
This feature introduces a new option called `dataProviderUrlHandler` to the
`srgOptions` object allowing developpers to create a custom URL handler to
query any back-end and still use SRGSSR functionality, as long as the returned
object conforms to the mediaCompostion.

The `dataProviderUrlHandler` option defines a function that takes an argument
symbolizing a content identifier and returns a string symbolizing the
URL of the back-end to be queried.

> [!TIP]
> How to use the `dataProviderUrlHandler` option

```javascript
const player = pillarbox('player', {
  srgOptions: {
    // defines the custom URL handler
    dataProviderUrlHandler: (id) => `https://my-domain.com/content/${id}`
  }
});

// load the src
player.src({src:'my-content-id', type:'srgssr/urn'});
```

> [!CAUTION]
> If the object returned by the server does not conform to the
> mediaComposition, unexpected errors may occur, preventing the video from
> playing.

## Changes made



- `dataProviderUrlHandler` property added to `srgOptions` object
- remove the `baseUrl` check from the `dataProviderError` allowing Error-type
errors to be handled
- rename the `getMediaComposition` function to `mediaCompositionUrlHandler`
function, which acts as the default url handler
- refactore the `DataProvider` to handle a `urlHandler`, while continuing to
handle back-end requests transparently
- adapt unit tests
- add an `urlHandler` query parameter to the development page, allowing to pass
a url returning a mediaComposition to the URN property. **For demonstration
purposes only!**
