### PR TITLE
feat: add pillarbox-js css as main theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 </head>
 
 <body>
-  <video id="player" class="video-js pillarbox-js" controls muted></video>
+  <video id="player" class="pillarbox-js" controls muted></video>
 
   <script type="module">
     import pillarbox from './src/pillarbox.js';

--- a/scss/pillarbox.scss
+++ b/scss/pillarbox.scss
@@ -6,6 +6,7 @@
 ******************************************************************************
 */
 .pillarbox-js {
+  @extend .video-js;
   @import "components/big-play";
   @import "components/captions-settings";
   @import "components/control";


### PR DESCRIPTION
## Description

This feature initializes the player with the default `pillarbox` CSS theme. This saves the developer from having to add `video-js` and then `pillarbox-js` in the CSS classes.

```html
<!-- Before -->
<video class="video-js pillarbox-js" controls>

<!-- After -->
<video class="pillarbox-js" controls>
```

However, it remains possible for a developer to use the default video.js theme if the use case so requires.

```html
<video class="video-js" controls>
```

## Changes made

- `pillarbox-js` CSS extends `video-js` CSS
- development page remove `video-js` class
