### PR TITLE
feat(player): add seekableRanges helper function

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -93,6 +93,26 @@ class Player extends vjsPlayer {
   }
 
   /**
+   * Calculates an array of ranges based on the `seekable()` data.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seekable
+   *
+   * @returns {Array<{start: number, end: number}>} An array of objects representing start and end points of seekable ranges.
+   */
+  seekableRanges() {
+    const ranges = [];
+
+    for (let i = 0; i < this.seekable().length; i++) {
+      const start = this.seekable().start(i);
+      const end = this.seekable().end(i);
+
+      ranges.push({ start, end });
+    }
+
+    return ranges;
+  }
+
+  /**
    * A getter/setter for the media's text track.
    * Activates the text track according to the language and kind properties.
    * Falls back on the first text track found if the kind property is not satisfied.

--- a/test/components/player.spec.js
+++ b/test/components/player.spec.js
@@ -95,6 +95,37 @@ describe('Player', () => {
     });
   });
 
+  describe('seekableRanges', () => {
+    it('should return an empty array if there are no seekable ranges', () => {
+      const player = new Player(videoEl);
+
+      player.seekable = jest.fn().mockImplementation(() => {
+        return pillarbox.time.createTimeRanges();
+      });
+
+      expect(player.seekableRanges()).toHaveLength(0);
+    });
+
+    it('should return an array containing two entries', () => {
+      const player = new Player(videoEl);
+
+      player.seekable = jest.fn().mockImplementation(() => {
+        return pillarbox.time.createTimeRanges([
+          [0, 10],
+          [11, 69]
+        ]);
+      });
+
+      expect(player.seekableRanges()).toHaveLength(2);
+      expect(player.seekableRanges()).toEqual(
+        expect.arrayContaining([
+          { 'end': 10, 'start': 0 },
+          { 'end': 69, 'start': 11 }
+        ])
+      );
+    });
+  });
+
   describe('textTrack', () => {
     const player = new Player(videoEl);
 


### PR DESCRIPTION
## Description

Adds a `seekableRanges` function which is particularly useful to get an array of ranges representing the portions of media that the user agent is able to seek to. `seekableRanges` uses the `seekable` function native to `HTMLMediaElement`.

## Changes made

- add seekableRanges function to the player
- add test coverage
