### PR TITLE
feat(player): add bufferedRanges helper function

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -73,6 +73,26 @@ class Player extends vjsPlayer {
   }
 
   /**
+   * Calculates an array of ranges based on the `buffered()` data.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/buffered
+   *
+   * @returns {Array<{start: number, end: number}>} An array of objects representing start and end points of buffered ranges.
+   */
+  bufferedRanges() {
+    const ranges = [];
+
+    for (let i = 0; i < this.buffered().length; i++) {
+      const start = this.buffered().start(i);
+      const end = this.buffered().end(i);
+
+      ranges.push({ start, end });
+    }
+
+    return ranges;
+  }
+
+  /**
    * A getter/setter for the media's text track.
    * Activates the text track according to the language and kind properties.
    * Falls back on the first text track found if the kind property is not satisfied.

--- a/test/components/player.spec.js
+++ b/test/components/player.spec.js
@@ -1,4 +1,5 @@
 import Player from '../../src/components/player.js';
+import pillarbox from '../../src/pillarbox.js';
 
 describe('Player', () => {
   const videoEl = document.createElement('video');
@@ -60,6 +61,37 @@ describe('Player', () => {
     it('should return undefined and not disable the already active audio track if the language and kind properties do not satisfy the condition', () => {
       expect(player.audioTrack({ language: 'fr' })).toBeUndefined();
       expect(player.audioTracks.mock.results[0].value[0].enabled).toBe(true);
+    });
+  });
+
+  describe('bufferedRanges', () => {
+    it('should return an empty array if there are no buffered ranges', () => {
+      const player = new Player(videoEl);
+
+      player.buffered = jest.fn().mockImplementation(() => {
+        return pillarbox.time.createTimeRanges();
+      });
+
+      expect(player.bufferedRanges()).toHaveLength(0);
+    });
+
+    it('should return an array containing two entries', () => {
+      const player = new Player(videoEl);
+
+      player.buffered = jest.fn().mockImplementation(() => {
+        return pillarbox.time.createTimeRanges([
+          [0, 10],
+          [11, 69]
+        ]);
+      });
+
+      expect(player.bufferedRanges()).toHaveLength(2);
+      expect(player.bufferedRanges()).toEqual(
+        expect.arrayContaining([
+          { 'end': 10, 'start': 0 },
+          { 'end': 69, 'start': 11 }
+        ])
+      );
     });
   });
 


### PR DESCRIPTION
## Description

Adds a `bufferedRanges` function which uses the `buffered` function native to
`HTMLMediaElement` and allows to know the status of the buffering performed by
the browser for a given media.

This function is particularly useful as it can highlight unsolicited gaps in
the media resulting in frame loss.

ref: https://github.com/videojs/http-streaming/issues/1369#issuecomment-1475965185

## Changes made

- add bufferedRanges function to the player
- add test coverage