### PR TITLE
feat: add exports field to package.json

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,9 @@ To get started with Pillarbox, add the `@srgssr` registry in your `.npmrc` file:
 @srgssr:registry=https://npm.pkg.github.com
 ```
 
-To generate an authentication token follow this
-guide: [Authenticating with a personal access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token)
+Generate a personal access token on the [Personal Access Tokens page][token-settings]. For more
+information on using tokens with GitHub packages,
+visit: [Authenticating with a Personal Access Token][token-guide].
 
 You can now install it through `npm` the following command:
 
@@ -35,7 +36,7 @@ In your HTML file, add the following code to initialize Pillarbox:
 Import the CSS file in your HTML to apply Pillarbox default theme:
 
 ```html
-<link rel="stylesheet" href="node_modules/@srgssr/pillarbox-web/dist/pillarbox.min.css" />
+<link rel="stylesheet" href="node_modules/@srgssr/pillarbox-web/dist/pillarbox.min.css"/>
 ```
 
 Finally, import Pillarbox and set up the player:
@@ -51,8 +52,14 @@ player.src({ src: 'urn:swi:video:48115940', type: 'srgssr/urn' });
 
 For detailed information on how to use the Pillarbox Web Player, checkout
 the [API Documentation](https://srgssr.github.io/pillarbox-web/api).
+
 A live demo of the player is available
-here: [Pillarbox Web Demo](https://srgssr.github.io/pillarbox-web-demo/)
+here: [Pillarbox Web Demo](https://srgssr.github.io/pillarbox-web-demo/).
+
+To expand the features that Pillarbox offers out of the box, visit the [Pillarbox Web
+Suite](https://github.com/SRGSSR/pillarbox-web-suite). You are welcome to contribute and share your
+own components there.
+
 You can create your own theme with
 the [Pillarbox Theme Editor](https://srgssr.github.io/pillarbox-web-theme-editor).
 
@@ -115,3 +122,7 @@ To contribute to the theme editor go to : https://github.com/SRGSSR/pillarbox-we
 ## License
 
 See the [LICENSE](../LICENSE) file for more information.
+
+[token-settings]: https://github.com/settings/tokens
+
+[token-guide]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,8 +12,9 @@ To get started with Pillarbox, add the `@srgssr` registry in your `.npmrc` file:
 @srgssr:registry=https://npm.pkg.github.com
 ```
 
-To generate an authentication token follow this
-guide: [Authenticating with a personal access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token)
+Generate a personal access token on the [Personal Access Tokens page][token-settings]. For more
+information on using tokens with GitHub packages,
+visit: [Authenticating with a Personal Access Token][token-guide].
 
 You can now install it through `npm` the following command:
 
@@ -24,13 +25,15 @@ npm install --save @srgssr/pillarbox-web
 In your HTML file, add the following code to initialize Pillarbox:
 
 ```html
+
 <video-js id="my-player" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
 ```
 
 Import the CSS file in your HTML to apply Pillarbox default theme:
 
 ```html
-<link rel="stylesheet" href="node_modules/@srgssr/pillarbox-web/dist/pillarbox.min.css" />
+
+<link rel="stylesheet" href="node_modules/@srgssr/pillarbox-web/dist/pillarbox.min.css"/>
 ```
 
 Finally, import Pillarbox and set up the player:
@@ -50,7 +53,6 @@ official [Video.js Player Workflows Guide](https://videojs.com/guides/player-wor
 More showcases and examples ara available in
 the [Pillarbox Demo Application](https://srgssr.github.io/pillarbox-web-demo/showcase).
 
-
 ## Further Reading
 
 Pillarbox serves as a superset of video.js, making all the available API features from video.js
@@ -60,7 +62,16 @@ class.
 To learn more about video.js, you can visit the [Video.js Guides](https://videojs.com/guides) and
 the [Video.js API docs](https://docs.videojs.com/).
 
+To expand the features that Pillarbox offers out of the box, visit the [Pillarbox Web
+Suite](https://github.com/SRGSSR/pillarbox-web-suite). You are welcome to contribute and share your
+own components there.
+
 Keep track of our [Known Issues](./tutorial-Known%20Issues.html) section.
 
 You can learn more about themes and create your own with
 the [Pillarbox Theme Editor](https://srgssr.github.io/pillarbox-web-theme-editor).
+
+
+[token-settings]: https://github.com/settings/tokens
+
+[token-guide]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token

--- a/package.json
+++ b/package.json
@@ -4,8 +4,15 @@
   "version": "1.11.1",
   "type": "module",
   "module": "dist/pillarbox.es.js",
+  "main": "dist/pillarbox.cjs.js",
   "style": "./dist/pillarbox.min.css",
   "types": "./dist/types/build.es.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/pillarbox.es.js",
+      "require": "./dist/pillarbox.cjs.js"
+    }
+  },
   "files": [
     "dist/*",
     "scss/*"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,6 +49,49 @@ export default [
     })]
   },
   /**
+   * Rollup build configuration for the Pillarbox CJS build.
+   *
+   * Outputs:
+   * - 'dist/pillarbox-core.cjs.min.js': Minified UMD version with sourcemaps.
+   * - 'dist/pillarbox-core.cjs.js': Non-minified UMD.
+   *
+   * @example
+   * ```html
+   * <script src="pillarbox-core.cjs.min.js"></script>
+   * ```
+   *
+   * @type {import('rollup').RollupOptions}
+   */
+  {
+    input: 'src/pillarbox.js',
+    output: [
+      {
+        name: 'Pillarbox',
+        file: 'dist/pillarbox-core.cjs.min.js',
+        format: 'cjs',
+        sourcemap: true,
+        globals: {
+          'video.js': 'videojs'
+        },
+        plugins: [terser()]
+      },
+      {
+        name: 'Pillarbox',
+        file: 'dist/pillarbox-core.cjs.js',
+        format: 'cjs',
+        globals: {
+          'video.js': 'videojs'
+        },
+        plugins: [filesize()]
+      }
+    ],
+    external: ['video.js', 'videojs-contrib-eme'],
+    plugins: [commonjs(), json(), resolve(), babel({
+      babelHelpers: 'bundled',
+      exclude: 'node_modules/**'
+    })]
+  },
+  /**
    * Rollup build configuration for the Pillarbox UMD build.
    *
    * Outputs:
@@ -113,6 +156,51 @@ export default [
     ],
     external: ['video.js', 'videojs-contrib-eme'],
     plugins: [json(), resolve(), babel({
+      babelHelpers: 'bundled',
+      exclude: 'node_modules/**'
+    })]
+  },
+
+  /**
+   * Rollup build configuration for the Pillarbox CJS build.
+   *
+   * Outputs:
+   * - 'dist/pillarbox.cjs.min.js': Minified UMD version with sourcemaps.
+   * - 'dist/pillarbox.cjs.js': Non-minified UMD.
+   *
+   * @example
+   * ```html
+   * <script src="pillarbox.cjs.min.js"></script>
+   * <script>
+   *   // Your additional code using Pillarbox as needed
+   * </script>
+   * ```
+   */
+  {
+    input: 'build.umd.js',
+    output: [
+      {
+        name: 'Pillarbox',
+        file: 'dist/pillarbox.cjs.min.js',
+        format: 'cjs',
+        sourcemap: true,
+        globals: {
+          'video.js': 'videojs'
+        },
+        plugins: [terser()]
+      },
+      {
+        name: 'Pillarbox',
+        file: 'dist/pillarbox.cjs.js',
+        format: 'cjs',
+        globals: {
+          'video.js': 'videojs'
+        },
+        plugins: [filesize()]
+      }
+    ],
+    external: ['video.js', 'videojs-contrib-eme'],
+    plugins: [commonjs(), json(), resolve(), babel({
       babelHelpers: 'bundled',
       exclude: 'node_modules/**'
     })]


### PR DESCRIPTION
## Description

Adds an 'exports' field in package.json to explicitly define entry points for ESM and CommonJS modules. This change ensures compatibility with different module systems and resolves module resolution issues in environments that rely on Node's resolution algorithm (like Vitest or Jest).

See: https://nodejs.org/api/esm.html#resolution-and-loading-algorithm

## Changes made

- Created a separate CommonJS builds for both core and non-core versions of pillarbox.
- Added a `main` field targeting the cjs build in the package.json for more flexibility.
- Added links to pillarbox-web-suite to the API documentation and README.
- Added a link to the personal accces token settings.