### PR TITLE
fix: add 'core' export and mapping for single files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     ".": {
       "import": "./dist/pillarbox.es.js",
       "require": "./dist/pillarbox.cjs.js"
-    }
+    },
+    "./core": {
+      "import": "./dist/pillarbox-core.es.js",
+      "require": "./dist/pillarbox-core.cjs.js"
+    },
+    "./*": "./*"
   },
   "files": [
     "dist/*",


### PR DESCRIPTION
## Description

Introduces a new export under the `core` mapping to facilitate the use of the core functionalities of the `pillarbox` library. Integrators can now easily access the core bundle by importing it directly in their projects as shown below:

```javascript
// Using ES6 import syntax
import pillarbox from '@srgssr/pillarbox-web/core';

// Using CommonJS syntax
const pillarbox = require('@srgssr/pillarbox-web/core');
```

This update also includes an export to allow for straightforward mapping of all files included in the final bundle.

## Changes made

- Additional mappings in the export option of the `package.json`.
