### PR TITLE
docs: remove crossorigin attribute from video-js tag in the examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ npm install --save @srgssr/pillarbox-web
 In your HTML file, add the following code to initialize Pillarbox:
 
 ```html
-<video-js id="my-player" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+<video-js id="my-player" class="pillarbox-js" controls></video-js>
 ```
 
 Import the CSS file in your HTML to apply Pillarbox default theme:

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -25,8 +25,7 @@ npm install --save @srgssr/pillarbox-web
 In your HTML file, add the following code to initialize Pillarbox:
 
 ```html
-
-<video-js id="my-player" class="pillarbox-js" controls crossorigin="anonymous"></video-js>
+<video-js id="my-player" class="pillarbox-js" controls></video-js>
 ```
 
 Import the CSS file in your HTML to apply Pillarbox default theme:


### PR DESCRIPTION
## Description

Removes the `crossorigin="anonymous"` attribute from the <video-js> tag in the examples because we were experiencing issues with cross-origin media. This change ensures that integrators won't encounter the same error.
