### PR TITLE
fix: publish pillarbox-web to npm

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run release:ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Pre-release main tag failed 🫣
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,8 @@ jobs:
         with:
           node-version: 20
           always-auth: true
-          registry-url: https://npm.pkg.github.com/
-          scope: '@srgssr'
       - run: |
           npm dist-tag add @srgssr/pillarbox-web@$(echo "${{github.ref_name}}" | cut -c 2-) latest
           exit 0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,18 +10,7 @@ experience of SRGSSR content, making it more accessible and feature-rich.
 
 ## Quick Start
 
-To get started with Pillarbox, add the `@srgssr` registry in your `.npmrc` file:
-
-```text
-//npm.pkg.github.com/:_authToken=TOKEN
-@srgssr:registry=https://npm.pkg.github.com
-```
-
-Generate a personal access token on the [Personal Access Tokens page][token-settings]. For more
-information on using tokens with GitHub packages,
-visit: [Authenticating with a Personal Access Token][token-guide].
-
-You can now install it through `npm` the following command:
+To get started with Pillarbox, install it through the following command:
 
 ```bash
 npm install --save @srgssr/pillarbox-web

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,18 +5,7 @@ Video.js.
 
 ## Quick Guide
 
-To get started with Pillarbox, add the `@srgssr` registry in your `.npmrc` file:
-
-```text
-//npm.pkg.github.com/:_authToken=TOKEN
-@srgssr:registry=https://npm.pkg.github.com
-```
-
-Generate a personal access token on the [Personal Access Tokens page][token-settings]. For more
-information on using tokens with GitHub packages,
-visit: [Authenticating with a Personal Access Token][token-guide].
-
-You can now install it through `npm` the following command:
+To get started with Pillarbox, install it through the following command:
 
 ```bash
 npm install --save @srgssr/pillarbox-web

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:watch": "jest --watch --verbose"
   },
   "keywords": [],
-  "author": "",
+  "author": "SRG SSR",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/SRGSSR/pillarbox-web/issues"
@@ -61,9 +61,9 @@
     "url": "git+https://github.com/SRGSSR/pillarbox-web.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
     "access": "public"
   },
+  "homepage": "https://srgssr.github.io/pillarbox-web-demo/",
   "devDependencies": {
     "@babel/core": "^7.24.1",
     "@babel/preset-env": "^7.24.1",


### PR DESCRIPTION
## Description

Resolves #260 by preparing the continuous integration for npm publishing.

## Changes made

- Updated GitHub Actions workflows to automate the publishing process to npm.
- Modified package.json files to ensure correct npm configuration.

