### PR TITLE
feat(player): send a beforesourceset event before a new source is set

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -27,6 +27,28 @@ class Player extends vjsPlayer {
   }
 
   /**
+   * Get or set the video source.
+   *
+   * If a source is provided, it triggers the `beforesourceset` event before setting the source.
+   *
+   * @override
+   * @fires Player#beforesourceset
+   *
+   * @see https://docs.videojs.com/player#src
+   *
+   * @return {string|undefined}
+   *         If the `source` argument is missing, returns the current source
+   *         URL. Otherwise, returns nothing/undefined.
+   */
+  src(source) {
+    if (source) {
+      this.trigger('beforesourceset');
+    }
+
+    return super.src(source);
+  }
+
+  /**
    * A getter/setter for the media's audio track.
    * Activates the audio track according to the language and kind properties.
    * Falls back on the first audio track found if the kind property is not satisfied.

--- a/test/components/player.spec.js
+++ b/test/components/player.spec.js
@@ -1,6 +1,13 @@
 import Player from '../../src/components/player.js';
 import pillarbox from '../../src/pillarbox.js';
 
+// jsdom doesn’t implement the HTMLMediaElement.prototype.load
+// Mainly used by the loadMedia test cases.
+Object.defineProperty(global.HTMLMediaElement.prototype, 'load', {
+  configurable: true,
+  value: () => {} // Noop function
+});
+
 describe('Player', () => {
   const videoEl = document.createElement('video');
 
@@ -258,6 +265,51 @@ describe('Player', () => {
       // When a plugin is initialized its function becomes an object
       expect(typeof player.eme).not.toBe('function');
       expect(typeof player.eme).toBe('object');
+    });
+  });
+
+  describe('src', () => {
+    const player = new Player(videoEl);
+
+    it('should not trigger the beforesourceset event when no parameter is passed to the src function', () => {
+      const handler = jest.fn();
+
+      player.on('beforesourceset', handler);
+      player.src();
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should trigger the beforesourceset event when a new source is passed to the src function', () => {
+      const handler = jest.fn();
+
+      player.on('beforesourceset', handler);
+      player.src('http://mock.url.ch');
+
+      expect(handler).toHaveBeenCalled();
+    });
+  });
+
+  // Ensures that the beforesourceset event also works with loadMedia
+  describe('loadMedia', () => {
+    const player = new Player(videoEl);
+
+    it('should not trigger the beforesourceset event when no parameter is passed to the loadMedia function', () => {
+      const handler = jest.fn();
+
+      player.on('beforesourceset', handler);
+      player.loadMedia();
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should trigger the beforesourceset event when a new source is passed to the loadMedia function', () => {
+      const handler = jest.fn();
+
+      player.on('beforesourceset', handler);
+      player.loadMedia({ src: { src: 'http://mock.url.ch' }});
+
+      expect(handler).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description

Adding the `beforesourceset` event, allows to perform operations before the new source is loaded.

## Changes made

- override the `src` function in the video.js `Player` class to trigger a `beforesourceset` event
- add test cases for `src` and `loadMedia` functions

