### PR TITLE
fix(pillarbox-monitoring): remove severity property from error event

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -248,7 +248,6 @@ class PillarboxMonitoring {
       message: error.message,
       name: error.code,
       ...playbackPosition,
-      severity: 'Fatal',
       url
     });
 


### PR DESCRIPTION
## Description

Resolves #277 by removing the `severity` property following the update of the 
monitoring specification.

