### PR TITLE
chore(github-actions): add registry url to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
           always-auth: true
       - run: |
           npm dist-tag add @srgssr/pillarbox-web@$(echo "${{github.ref_name}}" | cut -c 2-) latest


### PR DESCRIPTION
## Description

Adding the `registry-url` property to the `release` action should allow to select the tag to be promoted as the `latest` release from the github `releases` interface.

## Changes made

- add `registry-url` to `release.yml` file
