### PR TITLE
fix: update urls for custom domain setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pillarbox Web Player
 
-[![Pillarbox logo](README-images/logo.jpg)](https://github.com/SRGSSR/pillarbox-web)
+[![Pillarbox logo](docs/README-images/logo.jpg)](https://github.com/SRGSSR/pillarbox-web)
 
 ## About
 
@@ -40,17 +40,17 @@ player.src({ src: 'urn:swi:video:48115940', type: 'srgssr/urn' });
 ## Documentation
 
 For detailed information on how to use the Pillarbox Web Player, checkout
-the [API Documentation](https://srgssr.github.io/pillarbox-web/api).
+the [API Documentation](https://web.pillarbox.ch/api).
 
 A live demo of the player is available
-here: [Pillarbox Web Demo](https://srgssr.github.io/pillarbox-web-demo/).
+here: [Pillarbox Web Demo](https://demo.pillarbox.ch).
 
 To expand the features that Pillarbox offers out of the box, visit the [Pillarbox Web
 Suite](https://github.com/SRGSSR/pillarbox-web-suite). You are welcome to contribute and share your
 own components there.
 
 You can create your own theme with
-the [Pillarbox Theme Editor](https://srgssr.github.io/pillarbox-web-theme-editor).
+the [Pillarbox Theme Editor](https://editor.pillarbox.ch).
 
 ## Pillarbox flavours
 
@@ -110,7 +110,7 @@ To contribute to the theme editor go to: https://github.com/SRGSSR/pillarbox-web
 
 ## License
 
-See the [LICENSE](../LICENSE) file for more information.
+See the [LICENSE](LICENSE) file for more information.
 
 [token-settings]: https://github.com/settings/tokens
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -39,7 +39,7 @@ For a comprehensive guide on player workflows, refer to the
 official [Video.js Player Workflows Guide](https://videojs.com/guides/player-workflows/).
 
 More showcases and examples ara available in
-the [Pillarbox Demo Application](https://srgssr.github.io/pillarbox-web-demo/showcase).
+the [Pillarbox Demo Application](https://demo.pillarbox.ch/showcase).
 
 ## Further Reading
 
@@ -57,7 +57,7 @@ own components there.
 Keep track of our [Known Issues](./tutorial-Known%20Issues.html) section.
 
 You can learn more about themes and create your own with
-the [Pillarbox Theme Editor](https://srgssr.github.io/pillarbox-web-theme-editor).
+the [Pillarbox Theme Editor](https://editor.pillarbox.ch).
 
 
 [token-settings]: https://github.com/settings/tokens

--- a/docs/api/jsdoc.json
+++ b/docs/api/jsdoc.json
@@ -32,12 +32,12 @@
       "menu": [
         {
           "title": "Showcase",
-          "link": "https://srgssr.github.io/pillarbox-web-demo/showcase",
+          "link": "https://demo.pillarbox.ch/showcase",
           "target": "_blank"
         },
         {
           "title": "Theme Editor",
-          "link": "https://srgssr.github.io/pillarbox-web-theme-editor",
+          "link": "https://editor.pillarbox.ch",
           "target": "_blank"
         },
         {

--- a/docs/api/tutorials/Events.md
+++ b/docs/api/tutorials/Events.md
@@ -77,10 +77,10 @@ player.on('srgssr/interval', function ({ data }) {
 A showcase displaying a button to skip the end credits is available
 here: [Showcase: Skip Credits][intervals]
 
-[blocked-segments]: https://srgssr.github.io/pillarbox-web-demo/static/showcases/blocked-segment.html
+[blocked-segments]: https://demo.pillarbox.ch/static/showcases/blocked-segment.html
 
-[chapters]: https://srgssr.github.io/pillarbox-web-demo/static/showcases/chapters.html
+[chapters]: https://demo.pillarbox.ch/static/showcases/chapters.html
 
-[intervals]: https://srgssr.github.io/pillarbox-web-demo/static/showcases/skip-credits.html
+[intervals]: https://demo.pillarbox.ch/static/showcases/skip-credits.html
 
 [vjs-doc]: https://docs.videojs.com/

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://srgssr.github.io/pillarbox-web-demo/",
+  "homepage": "https://www.pillarbox.ch/",
   "devDependencies": {
     "@babel/core": "^7.24.1",
     "@babel/preset-env": "^7.24.1",


### PR DESCRIPTION
## Description

Use custom domain urls throughout the documentation.

## Changes made

- Updated all URLs to the demo page to point to `demo.pillarbox.ch`
- Updated all API documentation URLs to point to `web.pillarbox.ch/api`
- Updated all URLs to the theme editor to point to `editor.pillarbox.ch`
- Updated all URLs to the web suite demo to point to `plugins.pillarbox.ch`
- Updated all URLs to the marketing page to point to `www.pillarbox.ch`
- Updated all URLs to the Android documentation page to point to `android.pillarbox.ch`