### PR TITLE
fix(pillarbox-monitoring): inconsistent error name value

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -246,7 +246,7 @@ class PillarboxMonitoring {
       log: JSON
         .stringify(error.metadata || pillarbox.log.history().slice(-15)),
       message: error.message,
-      name: error.code,
+      name: PillarboxMonitoring.errorKeyCode(error.code),
       ...playbackPosition,
       url
     });
@@ -813,6 +813,25 @@ class PillarboxMonitoring {
       qos_timings: this.qosTimings(timeToLoadedData),
       screen: this.playerCurrentDimensions()
     };
+  }
+
+  /**
+   * Returns a string representing the error key combined with its error code.
+   *
+   * If the error code doesn't exist the error key undefined.
+   *
+   * @param {number} code The error code
+   *
+   * @returns {string} The error key combined with its error code
+   */
+  static errorKeyCode(code) {
+    const error = [
+      'MEDIA_ERR_CUSTOM',
+      ...Object.keys(window.MediaError),
+      'MEDIA_ERR_ENCRYPTED'
+    ];
+
+    return `${error[code]}: ${code}`;
   }
 
   /**

--- a/test/trackers/pillarbox-monitoring.spec.js
+++ b/test/trackers/pillarbox-monitoring.spec.js
@@ -7,6 +7,7 @@ describe('PillarboxMonitoring', () => {
   let monitoring;
 
   global.navigator.sendBeacon = jest.fn();
+  global.window.MediaError = jest.fn().mockReturnValue({  });
 
   beforeEach(() => {
     player = playerMock();


### PR DESCRIPTION
## Description

Fixes #283, by modifying the value of the error name sent, allowing clearer errors when consumed by other tools.

This modification supports the properties as defined by the [WHATWG](https://html.spec.whatwg.org/multipage/media.html#error-codes) as well as the two custom properties provided by video.js which are `MEDIA_ERR_CUSTOM` and `MEDIA_ERR_ENCRYPTED`.

## Changes made

- add a static method for setting the value of the error name
- add mock for `MediaError`
