### PR TITLE
feat(progress-control): remove play progress time tooltip

### DIFF
--- a/scss/components/_progress.scss
+++ b/scss/components/_progress.scss
@@ -23,11 +23,8 @@
   }
 }
 
-&.vjs-scrubbing,
-&.vjs-seeking {
-  .vjs-play-progress .vjs-time-tooltip {
-    display: none;
-  }
+.vjs-progress-control .vjs-play-progress .vjs-time-tooltip {
+  display: none;
 }
 
 .vjs-play-progress {


### PR DESCRIPTION
## Description

Remove the play progress time tooltip when hovering the mouse to avoid overlapping with the mouse display time tooltip when they are close.

## Changes made

- modify the rule to disable the display of the time tooltip

