### PR TITLE
feat(remaining-time-display): displays remaining time in x-small or tiny

### DIFF
--- a/scss/components/_layout.scss
+++ b/scss/components/_layout.scss
@@ -45,6 +45,15 @@
   font-weight: bold;
 }
 
+&:not(.vjs-live) {
+  &.vjs-layout-x-small .vjs-remaining-time,
+  &.vjs-layout-tiny .vjs-remaining-time {
+    display: block;
+    padding: 0;
+    font-weight: bold;
+  }
+}
+
 /*
 ******************************************************************************
 -- Progress control


### PR DESCRIPTION



## Description

When the current time and media duration are displayed, it's easy for the user to visualize the time remaining to play. However, when the player is displayed in x-small or tiny, no time indication is shown.

## Changes made

- modify `_layout.scss` to display the remaining time when the player is displayed in x-small or tiny

