### PR TITLE
feat: make analytics, data source and monitoring classes public

### DIFF
--- a/build.es.js
+++ b/build.es.js
@@ -1,5 +1,17 @@
 import SrgSsr from './src/middleware/srgssr.js';
 import Player from './src/components/player.js';
 import Pillarbox from './src/pillarbox.js';
+import DataProvider from './src/dataProvider/services/DataProvider.js';
+import MediaComposition from './src/dataProvider/model/MediaComposition.js';
+import PillarboxMonitoring from './src/trackers/PillarboxMonitoring.js';
+import SRGAnalytics from './src/trackers/SRGAnalytics.js';
 
-export { Pillarbox as default, Player, SrgSsr };
+export {
+  Pillarbox as default,
+  DataProvider,
+  MediaComposition,
+  PillarboxMonitoring,
+  Player,
+  SRGAnalytics,
+  SrgSsr
+};

--- a/docs/api/jsdoc.json
+++ b/docs/api/jsdoc.json
@@ -2,8 +2,9 @@
   "source": {
     "include": [
       "src/components/",
-      "src/dataProvider/model",
+      "src/dataProvider/",
       "src/middleware/",
+      "src/trackers/",
       "src/utils/typedef.ts",
       "src/pillarbox.js"
     ],

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -1,9 +1,14 @@
 import videojs from 'video.js';
 import 'videojs-contrib-eme';
 
+/** @import VJSPlayer from 'video.js/dist/types/player' */
+/** @import AudioTrack from 'video.js/dist/types/tracks/audio-track' */
+/** @import TextTrack from 'video.js/dist/types/tracks/text-track' */
+/** @import {TrackSelector} from './typedef' */
+
 /**
  * @ignore
- * @type {typeof import('video.js/dist/types/player').default}
+ * @type {typeof VJSPlayer}
  */
 const vjsPlayer = videojs.getComponent('player');
 
@@ -34,7 +39,7 @@ class Player extends vjsPlayer {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack/kind
    * @see https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack/language
    *
-   * @param {import('./typedef').TrackSelector} [trackSelector]
+   * @param {TrackSelector} [trackSelector]
    *
    * @example
    * // Get the current audio track
@@ -48,7 +53,7 @@ class Player extends vjsPlayer {
    * // Activate first audio track found corresponding to language
    * player.audioTrack({language:'fr'});
    *
-   * @return {import('video.js/dist/types/tracks/audio-track').default | undefined} The
+   * @return {AudioTrack | undefined} The
    *         currently enabled audio track. See {@link https://docs.videojs.com/audiotrack}.
    */
   audioTrack(trackSelector) {
@@ -167,7 +172,7 @@ class Player extends vjsPlayer {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/TextTrack/kind
    * @see https://developer.mozilla.org/en-US/docs/Web/API/textTrack/language
    *
-   * @param {import('./typedef').TrackSelector} [trackSelector]
+   * @param {TrackSelector} [trackSelector]
    *
    * @example
    * // Get the current text track
@@ -186,7 +191,7 @@ class Player extends vjsPlayer {
    * // Activate first text track found corresponding to language
    * player.textTrack({language:'fr'});
    *
-   * @return {import('video.js/dist/types/tracks/text-track').default | undefined} The
+   * @return {TextTrack | undefined} The
    *         currently enabled text track. See {@link https://docs.videojs.com/texttrack}.
    */
   textTrack(trackSelector) {

--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -1,4 +1,17 @@
 /**
+ * @typedef {import('./typedef').Channel} Channel
+ * @typedef {import('./typedef').Chapter} Chapter
+ * @typedef {import('./typedef').Episode} Episode
+ * @typedef {import('./typedef').Resource} Resource
+ * @typedef {import('./typedef').Segment} Segment
+ * @typedef {import('./typedef').Show} Show
+ * @typedef {import('./typedef').Subtitle} Subtitle
+ * @typedef {import('./typedef').TimeInterval} TimeInterval
+ * @typedef {import('./typedef').Topic} Topic
+ * @typedef {import('./typedef').MainResource} MainResource
+ */
+
+/**
  * Represents the composition of media content.
  *
  * @class MediaComposition
@@ -324,17 +337,3 @@ class MediaComposition {
 }
 
 export default MediaComposition;
-
-
-/**
- * @typedef {import('./typedef').Channel} Channel
- * @typedef {import('./typedef').Chapter} Chapter
- * @typedef {import('./typedef').Episode} Episode
- * @typedef {import('./typedef').Resource} Resource
- * @typedef {import('./typedef').Segment} Segment
- * @typedef {import('./typedef').Show} Show
- * @typedef {import('./typedef').Subtitle} Subtitle
- * @typedef {import('./typedef').TimeInterval} TimeInterval
- * @typedef {import('./typedef').Topic} Topic
- * @typedef {import('./typedef').MainResource} MainResource
- */

--- a/src/dataProvider/services/DataProvider.js
+++ b/src/dataProvider/services/DataProvider.js
@@ -1,7 +1,8 @@
+/** @import MediaComposition from '../model/MediaComposition.js' */
+
 /**
  * Represents a data provider for constructing URLs and handling requests.
  * @class
- * @ignore
  */
 class DataProvider {
   /**
@@ -29,7 +30,7 @@ class DataProvider {
    *
    * @param {Function} urlHandler A function that constructs the URL
    *
-   * @returns {Promise<import('../model/MediaComposition.js').default>} A promise with the fetched data
+   * @returns {Promise<MediaComposition>} A promise with the fetched data
    */
   handleRequest(urlHandler) {
     return async (urn) => {
@@ -40,7 +41,7 @@ class DataProvider {
         throw response;
       }
 
-      /** @type {import('../model/MediaComposition.js').default} */
+      /** @type {MediaComposition} */
       const data = await response.json();
 
       return data;

--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -14,6 +14,10 @@ import '../lang/fr.js';
 import '../lang/it.js';
 import '../lang/rm.js';
 
+/** @import Player from 'video.js/dist/types/player' */
+/** @import {Chapter, MainResource, Segment, Subtitle, TimeInterval} from '../dataProvider/model/typedef' */
+/** @import {ComposedSrcMediaData, MainResourceWithKeySystems} from './typedef' */
+
 /**
  * @class SrgSsr
  */
@@ -21,8 +25,8 @@ class SrgSsr {
   /**
    * Adds blocked segments to the player.
    *
-   * @param {import('video.js/dist/types/player').default} player
-   * @param {Array<import('../dataProvider/model/typedef').Segment>} [segments=[]]
+   * @param {Player} player
+   * @param {Array<Segment>} [segments=[]]
    */
   static addBlockedSegments(player, segments = []) {
     const trackId = 'srgssr-blocked-segments';
@@ -50,8 +54,8 @@ class SrgSsr {
   /**
    * Adds remote text tracks from an array of subtitles.
    *
-   * @param {import('video.js/dist/types/player').default} player
-   * @param {Array<import('../dataProvider/model/typedef').Subtitle>} [subtitles=[]]
+   * @param {Player} player
+   * @param {Array<Subtitle>} [subtitles=[]]
    */
   static addRemoteTextTracks(player, subtitles = []) {
     if (!Array.isArray(subtitles)) return;
@@ -76,9 +80,9 @@ class SrgSsr {
    *
    * @param {TextTrack} textTrack
    * @param {
-   *   import('../dataProvider/model/typedef').Segment |
-   *   import('../dataProvider/model/typedef').Chapter |
-   *   import('../dataProvider/model/typedef').TimeInterval
+   *   Segment |
+   *   Chapter |
+   *   TimeInterval
    * } data SRG SSR's cue-like representation
    */
   static addTextTrackCue(textTrack, data) {
@@ -97,8 +101,8 @@ class SrgSsr {
   /**
    * Add multiple text tracks to the player.
    *
-   * @param {import('video.js/dist/types/player').default} player
-   * @param {import('./typedef').ComposedSrcMediaData} srcMediaObj
+   * @param {Player} player
+   * @param {ComposedSrcMediaData} srcMediaObj
    */
   static addTextTracks(player, { mediaData }) {
     SrgSsr.addRemoteTextTracks(player, mediaData.subtitles);
@@ -110,9 +114,9 @@ class SrgSsr {
   /**
    * Adds chapters to the player.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {string} chapterUrn The URN of the main chapter.
-   * @param {Array.<import('../dataProvider/model/typedef').Chapter>} [chapters=[]]
+   * @param {Array.<Chapter>} [chapters=[]]
    */
   static addChapters(player, chapterUrn, chapters = []) {
     const trackId = 'srgssr-chapters';
@@ -138,8 +142,8 @@ class SrgSsr {
   /**
    * Adds intervals to the player.
    *
-   * @param {import('video.js/dist/types/player').default} player
-   * @param {Array.<import('../dataProvider/model/typedef').TimeInterval>} [intervals=[]]
+   * @param {Player} player
+   * @param {Array.<TimeInterval>} [intervals=[]]
    */
   static addIntervals(player, intervals = []) {
     const trackId = 'srgssr-intervals';
@@ -164,8 +168,8 @@ class SrgSsr {
    * Set a blocking reason according to the block reason returned
    * by mediaData.
    *
-   * @param {import('video.js/dist/types/player').default} player
-   * @param {import('./typedef').ComposedSrcMediaData} srcMediaObj
+   * @param {Player} player
+   * @param {ComposedSrcMediaData} srcMediaObj
    *
    * @returns {undefined|Boolean}
    */
@@ -191,9 +195,9 @@ class SrgSsr {
    * if at least one of them has tokenType
    * set to Akamai.
    *
-   * @param {Array.<import('./typedef').MainResourceWithKeySystems>} resources
+   * @param {Array.<MainResourceWithKeySystems>} resources
    *
-   * @returns {Promise<Array.<import('./typedef').MainResourceWithKeySystems>>}
+   * @returns {Promise<Array.<MainResourceWithKeySystems>>}
    */
   static async composeAkamaiResources(resources = []) {
     if (!AkamaiTokenService.hasToken(resources)) {
@@ -208,9 +212,9 @@ class SrgSsr {
    * Add the keySystems property to all resources
    * if at least one of them has DRM.
    *
-   * @param {Array.<import('../dataProvider/model/typedef').MainResource>} resources
+   * @param {Array.<MainResource>} resources
    *
-   * @returns {Array.<import('./typedef').MainResourceWithKeySystems>}
+   * @returns {Array.<MainResourceWithKeySystems>}
    */
   static composeKeySystemsResources(resources = []) {
     if (!Drm.hasDrm(resources)) return resources;
@@ -229,7 +233,7 @@ class SrgSsr {
    *
    * @param {MediaComposition} mediaComposition
    *
-   * @returns {Promise<Array.<import('./typedef').MainResourceWithKeySystems>>}
+   * @returns {Promise<Array.<MainResourceWithKeySystems>>}
    */
   static composeMainResources(mediaComposition) {
     return SrgSsr.composeAkamaiResources(
@@ -246,9 +250,9 @@ class SrgSsr {
    * @param {any} srcObj
    * @param {any} srcObj.mediaData overrides or adds metadata to the composed mediaData.
    * @param {boolean} srcObj.disableTrackers
-   * @param {import('./typedef').MainResourceWithKeySystems} resource
+   * @param {MainResourceWithKeySystems} resource
    *
-   * @returns {import('./typedef').ComposedSrcMediaData}
+   * @returns {ComposedSrcMediaData}
    */
   static composeSrcMediaData(
     { mediaData: srcMediaData, disableTrackers },
@@ -273,7 +277,7 @@ class SrgSsr {
   /**
    * Create a new metadata text track.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {String} trackId Text track unique ID
    *
    * @returns {Promise<TextTrack>}
@@ -295,7 +299,7 @@ class SrgSsr {
   /**
    * Proxy SRG SSR chapters and intervals cuechange events at player level.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    */
   static cuechangeEventProxy(player) {
     player.textTracks().on('addtrack', ({ track }) => {
@@ -313,7 +317,7 @@ class SrgSsr {
   /**
    * SRG SSR data provider singleton.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    *
    * @returns {DataProvider}
    */
@@ -340,7 +344,7 @@ class SrgSsr {
   /**
    * Set an error if something goes wrong with the data provider.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {Object} error
    *
    * @returns {undefined|true}
@@ -368,7 +372,7 @@ class SrgSsr {
   /**
    * Set player error.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {Object} error
    */
   static error(player, { code, message, metadata }) {
@@ -384,9 +388,9 @@ class SrgSsr {
   /**
    * Filter out incompatible resources such as `RTMP` and `HDS`.
    *
-   * @param {Array.<import('../dataProvider/model/typedef').MainResource>} resources Resources to filter
+   * @param {Array.<MainResource>} resources Resources to filter
    *
-   * @returns {Array.<import('../dataProvider/model/typedef').MainResource>} The filtered resources
+   * @returns {Array.<MainResource>} The filtered resources
    */
   static filterIncompatibleResources(resources = []) {
     return resources.filter(
@@ -397,7 +401,7 @@ class SrgSsr {
   /**
    * Get the current blocked segment from the player.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    *
    * @returns {VTTCue|undefined} The blocked segment cue object, or undefined
    */
@@ -416,7 +420,7 @@ class SrgSsr {
   /**
    * Get the VTT cue of a blocked segment.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {Number} currentTime
    *
    * @returns {VTTCue|undefined} The VTT cue of a blocked segment, or undefined
@@ -452,9 +456,9 @@ class SrgSsr {
   /**
    * Get the mediaData most likely to be compatible depending on the browser.
    *
-   * @param {Array.<import('./typedef').MainResourceWithKeySystems>} resources
+   * @param {Array.<MainResourceWithKeySystems>} resources
    *
-   * @returns {import('./typedef').MainResourceWithKeySystems} By default, the first entry is used if none is compatible.
+   * @returns {MainResourceWithKeySystems} By default, the first entry is used if none is compatible.
    */
   static getMediaData(resources = []) {
     if (AkamaiTokenService.hasToken(resources)) return resources[0];
@@ -468,10 +472,10 @@ class SrgSsr {
   /**
    * Get the source media object.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {any} srcObj
    *
-   * @returns {Promise<import('./typedef').ComposedSrcMediaData>} - The composed source media data.
+   * @returns {Promise<ComposedSrcMediaData>} - The composed source media data.
    */
   static async getSrcMediaObj(player, srcObj) {
     if (SrgSsr.pillarboxMonitoring(player)) {
@@ -506,7 +510,7 @@ class SrgSsr {
    * _Note_: This function should disappear as soon as this behavior is
    *         supported on the packaging side.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {number} currentTime
    *
    * @returns {number}
@@ -538,7 +542,7 @@ class SrgSsr {
    * _Note_: This function should disappear as soon as this behavior is
    *         supported on the packaging side.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {number} currentTime
    *
    * @returns {number}
@@ -561,7 +565,7 @@ class SrgSsr {
    * - handle blocking reasons
    * - add remote subtitles
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    * @param {any} srcObj
    * @param {function} next
    *
@@ -590,7 +594,7 @@ class SrgSsr {
   /**
    * SRG SSR analytics singleton.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    */
   static srgAnalytics(player) {
     if (player.options().trackers.srgAnalytics === false) return;
@@ -614,7 +618,7 @@ class SrgSsr {
   /**
    * PillarboxMonitoring monitoring singleton.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    *
    * @returns {PillarboxMonitoring} instance of PillarboxMonitoring
    */
@@ -641,8 +645,8 @@ class SrgSsr {
   /**
    * Update player's poster.
    *
-   * @param {import('video.js/dist/types/player').default} player
-   * @param {import('./typedef').ComposedSrcMediaData} srcMediaObj
+   * @param {Player} player
+   * @param {ComposedSrcMediaData} srcMediaObj
    * @param {Image} imageService
    */
   static updatePoster(player, srcMediaObj, imageService = Image) {
@@ -656,8 +660,8 @@ class SrgSsr {
   /**
    * Update player titleBar with title and description.
    *
-   * @param {import('video.js/dist/types/player').default} player
-   * @param {import('./typedef').ComposedSrcMediaData} srcMediaObj
+   * @param {Player} player
+   * @param {ComposedSrcMediaData} srcMediaObj
    */
   static updateTitleBar(player, srcMediaObj) {
     if (!player.titleBar) return;
@@ -671,7 +675,7 @@ class SrgSsr {
   /**
    * Middleware to resolve SRG SSR URNs into playable media.
    *
-   * @param {import('video.js/dist/types/player').default} player
+   * @param {Player} player
    *
    * @returns {Object}
    */

--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -1,5 +1,7 @@
 import pillarbox from '../pillarbox.js';
 
+/** @import Player from 'video.js/dist/types/player' */
+
 /* eslint max-statements: ["error", 25]*/
 
 /**
@@ -18,6 +20,19 @@ import pillarbox from '../pillarbox.js';
  * @see https://github.com/SRGSSR/pillarbox-documentation/blob/main/Specifications/monitoring.md
  */
 class PillarboxMonitoring {
+  /**
+   * Creates an instance of PillarboxMonitoring.
+   *
+   * @constructor
+   * @param {Player} player The player instance to be monitored
+   * @param {PillarboxMonitoringOptions} [options={}] Configuration options for the monitoring
+   * @param {string} [options.playerName='none'] The name of the player
+   * @param {string} [options.playerVersion='none'] The version of the player
+   * @param {string} [options.platform='Web'] The platform on which the player is running
+   * @param {number} [options.schemaVersion=1] The version of the schema used for monitoring
+   * @param {number} [options.heartbeatInterval=30000] The interval in milliseconds for sending heartbeat signals
+   * @param {string} [options.beaconUrl='https://monitoring.pillarbox.ch/api/events'] The URL for the monitoring beacon
+   */
   constructor(player, {
     playerName = 'none',
     playerVersion = 'none',

--- a/src/trackers/SRGAnalytics.js
+++ b/src/trackers/SRGAnalytics.js
@@ -1,66 +1,65 @@
 import * as PlayerEvents from '../utils/PlayerEvents.js';
 import Pillarbox from '../pillarbox.js';
+
+/** @import Player from 'video.js/dist/types/player' */
+
 /* eslint max-lines-per-function: ["error", 200] */
 /* eslint max-statements: ["error", 20]*/
 /* eslint complexity: ["error", 10]*/
+
 /**
- * SRG analytics
- * @class SRGAnalytics
- * @ignore
+ * The SRG analytics class tracks media playback according to the standard defined by SRG SSR.
  *
- * ### Script URL
- * JS script : https://colibri-js.akamaized.net/penguin/tc_SRGGD_11.js
+ * @class SRGAnalytics
  *
  * ### Official documentation
- * Variables list
- * @see https://confluence.srg.beecollaboration.com/display/INTFORSCHUNG/Datalayer+for+media+players
  *
- * Standard event sequences
- * @see https://confluence.srg.beecollaboration.com/display/INTFORSCHUNG/standard+streaming+events%3A+sequence+of+events+for+media+player+actions
+ * - [New variable list]{@link https://srgssr-ch.atlassian.net/wiki/spaces/INTFORSCHUNG/pages/1009353309/Labels+check+for+migration+of+integration+layer+in+SAM}
+ * - [Variables list]{@link https://srgssr-ch.atlassian.net/wiki/spaces/INTFORSCHUNG/pages/795904478/Datalayer+for+media+players}
+ * - [Standard event sequences]{@link https://srgssr-ch.atlassian.net/wiki/spaces/INTFORSCHUNG/pages/795904171/standard+streaming+events+sequence+of+events+for+media+player+actions}
+ * - [Review of Standard Media Actions]{@link https://srgssr-ch.atlassian.net/wiki/spaces/INTFORSCHUNG/pages/795902249/Implementation+Concept+-+draft}
+ * - [ComScore Implementation Guide]{@link https://www.dropbox.com/sh/cdwuikq0abxi21m/AABmSyXYKUTWSAwRZgQA9Ujna/JavaScript%20Latest%20Version?dl=0&preview=Comscore_Library-JavaScript-Streaming_Tag-Implementation_Guide-International.pdf&subfolder_nav_tracking=1}
  *
- * Review of Standard Media Actions
- * @see https://confluence.srg.beecollaboration.com/display/INTFORSCHUNG/Implementation+Concept+-+draft
+ * ### Script URL
  *
- * ComScore Implementation Guide
- * @see https://www.dropbox.com/sh/cdwuikq0abxi21m/AABmSyXYKUTWSAwRZgQA9Ujna/JavaScript%20Latest%20Version?dl=0&preview=Comscore_Library-JavaScript-Streaming_Tag-Implementation_Guide-International.pdf&subfolder_nav_tracking=1
+ * JS script : https://colibri-js.akamaized.net/penguin/tc_SRGGD_11.js
  *
  * ### Variables list
- * - 'event_id', // init | play | stop | pos | pause | seek | uptime | eof
- * - 'event_timestamp', // Seems to be generated automatically from the documentation, but the TP overrides it
- * - 'event_name', // NA TP seems to not sending this variable
- * - 'event_source', // NA TP seems to not sending this variable
- * - 'event_name', // NA TP seems to not sending this variable
- * - 'event_value', // NA TP seems to not sending this variable
- * - 'navigation_environment', // prod | preprod
- * - 'media_subtitles_on', // string true | false
- * - 'media_timeshift', // need better description
- * - 'media_quality', // SD | HD ?
- * - 'media_bandwidth', // NA for the web, 64000
- * - 'media_volume', // from 0 to 100
- * - 'media_embedding_url', //
- * - 'media_player_name', // videojs | letterbox-web ?
- * - 'media_chromecast_selected', // boolean true | false
- * - 'media_player_version', // player's version
- * - 'media_player_display', // is the player mode, on the TP : inline, embed etc..
- * - 'media_audio_track', // NA
- * - 'media_position_real', // NA
- * - 'media_time_spent', // NA
- * - 'device_id', // NA
- * - 'user_id_log_in', // NA only RTS has log in today
- * - 'media_thumbnail', // Not required by the spec but sended by the TP
- * - 'media_bu_distributer', // Not required by the spec but sended by the TP
  *
+ * - event_id: init | play | stop | pos | pause | seek | uptime | eof
+ * - event_timestamp: Seems to be generated automatically from the documentation, but the TP overrides it
+ * - event_name: NA TP seems to not sending this variable
+ * - event_source: NA TP seems to not sending this variable
+ * - event_name: NA TP seems to not sending this variable
+ * - event_value: NA TP seems to not sending this variable
+ * - navigation_environment: prod | preprod
+ * - media_subtitles_on: string true | false
+ * - media_timeshift: need better description
+ * - media_quality: SD | HD ?
+ * - media_bandwidth: NA for the web, 64000
+ * - media_volume: from 0 to 100
+ * - media_embedding_url:
+ * - media_player_name: videojs | letterbox-web ?
+ * - media_chromecast_selected: boolean true | false
+ * - media_player_version: player's version
+ * - media_player_display: is the player mode, on the TP : inline, embed etc..
+ * - media_audio_track: NA
+ * - media_position_real: NA
+ * - media_time_spent: NA
+ * - device_id: NA
+ * - user_id_log_in: NA only RTS has log in today
+ * - media_thumbnail: Not required by the spec but sended by the TP
+ * - media_bu_distributer: Not required by the spec but sended by the TP
  *
  * ### Sequence stories
  *
- * __Story 1 (AoD/VOD-basics)__: A VoD is played. The user does not interact with the player. The VoD plays to its end.
+ * #### Story 1 (AoD/VOD-basics): A VoD is played. The user does not interact with the player. The VoD plays to its end.
  *
  * Hints:
  * - Media sessions always start with PLAY. They end with STOP or EOF (or with PAUSE or last POS)
  * - POS is sent ever 30s
  *
- *
- * __Story 2 (livestream-basics A)__: A Livestream is played. The user does not interact with the player. After 61 seconds, playback is paused.
+ * #### Story 2 (livestream-basics A): A Livestream is played. The user does not interact with the player. After 61 seconds, playback is paused.
  *
  * Hints:
  * - Media sessions always start with PLAY. They end with STOP (or, worse for data quailty, with PAUSE or last POS/UPTIME)
@@ -68,14 +67,12 @@ import Pillarbox from '../pillarbox.js';
  * - POS is sent ever 30s, UPTIME every 60s with inital UPTIME after 30s.
  * - This is the interval: 30s: POS + UPTIME; 60s: POS; 90s: POS + UPTIME; ...
  *
- *
- * __Story 3 (Seeking a VoD/AoD)__: A VoD is played. User seeks in the VoD/AoD.
+ * #### Story 3 (Seeking a VoD/AoD): A VoD is played. User seeks in the VoD/AoD.
  *
  * Hints:
  * - Once the Media Player slider is released (seek is over), another action to finish up the seeking is initiated. Typically this is PLAY. For that second PLAY, the media position has altered.
  *
- *
- * __Story 4 (Seeking a livestream)__: A Livestream is played. User goes back in the livestream.
+ * #### Story 4 (Seeking a livestream): A Livestream is played. User goes back in the livestream.
  *
  * Hints:
  * - Once the Media Player slider is released (seek is over), another action to finish up the seeking is initiated. Typically this is PLAY.  For that second PLAY, the a new variable, media_timeshift is passed.
@@ -84,6 +81,17 @@ import Pillarbox from '../pillarbox.js';
  *  2. The value of media_position is '1'.
  */
 class SRGAnalytics {
+  /**
+   * Creates an instance of SRGAnalytics.
+   *
+   * @constructor
+   * @param {Player} player The player instance
+   * @param {SRGAnalyticsOptions} [options={}] Configuration options
+   * @param {boolean} [options.debug=false] Enables debug mode if set to true
+   * @param {string} [options.environment='prod'] The environment in which the data is sent
+   * @param {string} [options.playerVersion='none'] The version of the player
+   * @param {string} [options.tagCommanderScriptURL='//colibri-js.akamaized.net/penguin/tc_SRGGD_11.js'] The URL for the Tag Commander script
+   */
   constructor(
     player,
     {

--- a/src/trackers/typedef.ts
+++ b/src/trackers/typedef.ts
@@ -1,0 +1,39 @@
+/**
+ * SRG Analytics configuration options.
+ */
+export type SRGAnalyticsOptions = {
+  /** Enables debug mode if set to true */
+  debug: boolean;
+
+  /** The environment in which the player is running */
+  environment: string;
+
+  /** The version of the player */
+  playerVersion: string;
+
+  /** The URL for the Tag Commander script */
+  tagCommanderScriptURL: string;
+};
+
+/**
+ * Pillarbox Monitoring configuration options.
+ */
+export type PillarboxMonitoringOptions = {
+  /** The name of the player */
+  playerName: string;
+
+  /** The version of the player */
+  playerVersion: string;
+
+  /** The platform on which the player is running */
+  platform: string;
+
+  /** The version of the schema used for monitoring */
+  schemaVersion: number;
+
+  /** The interval in milliseconds for sending heartbeat signals */
+  heartbeatInterval: number;
+
+  /** The URL for the monitoring beacon */
+  beaconUrl: string;
+};


### PR DESCRIPTION
## Description

Resolves #297 by exposing business classes, enabling their reuse across different projects.

## Changes made

- `build.es.js`, update to expose the following classes: `DataProvider`, `MediaComposition`, `PillarboxMonitoring`, and `SRGAnalytics`
- `jsdoc.json`, modify configuration to generate documentation for the exposed classes
- `PillarboxMonitoring`, add constructor documentation and created a type for constructor options
- `SRGAnalytics`, add constructor documentation and created a type for constructor options, update  links to the official documentation and reformatted documentation blocks for clarity