### PR TITLE
fix(pillarbox-monitoring): sendEvent payload sent has a JSON string

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -625,12 +625,14 @@ class PillarboxMonitoring {
       !this.currentSessionId
     ) return;
 
-    const payload = JSON.stringify({
+    const payload = new Blob([JSON.stringify({
       event_name: eventName,
       session_id: this.currentSessionId,
       timestamp: PillarboxMonitoring.timestamp(),
       version: this.schemaVersion,
       data
+    })], {
+      type: 'application/json'
     });
 
     navigator.sendBeacon(

--- a/test/trackers/pillarbox-monitoring.spec.js
+++ b/test/trackers/pillarbox-monitoring.spec.js
@@ -558,7 +558,7 @@ describe('PillarboxMonitoring', () => {
         property: 'value'
       });
 
-      expect(spyOnSendBeacon).toHaveBeenCalledWith(expect.any(String), expect.any(String));
+      expect(spyOnSendBeacon).toHaveBeenCalledWith(expect.any(String), expect.any(Blob));
     });
 
     it('should only send a STOP event if there was a previous session', () => {
@@ -581,7 +581,7 @@ describe('PillarboxMonitoring', () => {
       });
 
       expect(spyOnSendBeacon).toHaveBeenCalledTimes(1);
-      expect(spyOnSendBeacon).toHaveBeenCalledWith(expect.any(String), expect.any(String));
+      expect(spyOnSendBeacon).toHaveBeenCalledWith(expect.any(String), expect.any(Blob));
 
       spyOnIsTrackerDisabled.mockRestore();
     });


### PR DESCRIPTION
## Description

Fixes #302 by improving compatibility and reliability of the event transmission.

## Changes made

- replace the JSON string payload with a Blob object to ensure proper handling of the data type when sending events to the server using the Beacon API
- update `sendEvent` test cases

