### PR TITLE
feat(media-composition): add media container

### DIFF
--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -235,6 +235,7 @@ class MediaComposition {
       imageCopyright: this.getMainChapter().imageCopyright,
       intervals: this.getMainTimeIntervals(),
       live: resource.live,
+      mediaContainer: resource.mediaContainer,
       mediaType: this.getMainChapter().mediaType,
       mimeType: resource.mimeType,
       presentation: resource.presentation,


### PR DESCRIPTION
## Description

Exposes the (video) media container from the `mediaComposition`. This property will be exposed by the player through `mediaData` and will allow it to be used by the Google Cast receiver.

## Changes made

- expose the `mediaContainer` property via the `getMainResources` method.

