### PR TITLE
feat(pillarbox-monitoring): add subtitles and audio track language

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -184,6 +184,19 @@ class PillarboxMonitoring {
   }
 
   /**
+   * Gets the language of the current audio track.
+   *
+   * @returns {string|undefined} The language of the current audio track, or undefined if no audio track is available or if the language is not set.
+   */
+  currentAudioTrack() {
+    const audioTrack = this.player.audioTrack();
+
+    if (!audioTrack || !audioTrack.language) return;
+
+    return audioTrack.language;
+  }
+
+  /**
    * Get the current representation when playing a Dash or Hls media.
    *
    * @typedef {Object} Representation
@@ -244,25 +257,42 @@ class PillarboxMonitoring {
   }
 
   /**
+   * Gets the language of the current text track (subtitles or captions).
+   *
+   * @returns {string|undefined} The language of the current text track, or undefined if no text track is available or if the language is not set.
+   */
+  currentTextTrack() {
+    const textTrack = this.player.textTrack();
+
+    if (!textTrack || !textTrack.language) return;
+
+    return textTrack.language;
+  }
+
+  /**
    * Handles player errors by sending an `ERROR` event, then resets the session.
    */
   error() {
+    const audio = this.currentAudioTrack();
     const error = this.player.error();
     const playbackPosition = this.playbackPosition();
     const representation = this.currentRepresentation();
     const url = representation ?
       representation.uri : this.player.currentSource().src;
+    const subtitles = this.currentTextTrack();
 
     if (!this.player.hasStarted()) {
       this.sendEvent('START', this.startEventData());
     }
 
     this.sendEvent('ERROR', {
+      audio,
       log: JSON
         .stringify(error.metadata || pillarbox.log.history().slice(-15)),
       message: error.message,
       name: PillarboxMonitoring.errorKeyCode(error.code),
       ...playbackPosition,
+      subtitles,
       url
     });
 
@@ -752,6 +782,7 @@ class PillarboxMonitoring {
    * @returns {StatusEventData} The current event data
    */
   statusEventData() {
+    const audio = this.currentAudioTrack();
     const bandwidth = this.bandwidth();
     const buffered_duration = this.bufferDuration();
     const { bitrate, url } = this.currentResource();
@@ -762,8 +793,10 @@ class PillarboxMonitoring {
     const { position, position_timestamp } = this.playbackPosition();
     const stream_type = isFinite(this.player.duration()) ? 'On-demand' : 'Live';
     const stall = this.stallInfo();
+    const subtitles = this.currentTextTrack();
 
     const data = {
+      audio,
       bandwidth,
       bitrate,
       buffered_duration,
@@ -773,6 +806,7 @@ class PillarboxMonitoring {
       position_timestamp,
       stall,
       stream_type,
+      subtitles,
       url,
     };
 

--- a/test/__mocks__/player-mock.js
+++ b/test/__mocks__/player-mock.js
@@ -1,6 +1,7 @@
 import * as mediaData from '../__mocks__/mediaData.json';
 
 let playerMock = jest.fn(() => ({
+  audioTrack: jest.fn().mockReturnValue({}),
   audioTracks: jest.fn().mockReturnValue({}),
   buffered: jest.fn().mockReturnValue({ length: 0, start: jest.fn(), end: jest.fn() }),
   currentDimensions: jest.fn().mockReturnValue({ width: 1024, height: 768 }),


### PR DESCRIPTION
## Description

Resolves #305 by retrieving the current audio and subtitle track languages from the player. Each time a `HEARTBEAT` or `ERROR` event occurs, the current audio and subtitle track will be added to the payload. This enhancement will help recreate the exact same context if needed for debugging or analysis.

## Changes made

- add a method to get the current audio track language
- add a method to get the current text track language
- add audio and text track language to the `HEARTBEAT` payload
- add audio and text track language to the `ERROR` payload
- test add mock for the audioTrack method

