### PR TITLE
feat(lang): add VPN blocking reason

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -7,5 +7,6 @@
   "JOURNALISTIC": "Dieser Inhalt steht aus publizistischen Gründen vorübergehend nicht zur Verfügung.",
   "LEGAL": "Dieser Inhalt ist aus rechtlichen Gründen nicht verfügbar.",
   "STARTDATE": "Dieser Inhalt ist noch nicht verfügbar. Bitte probieren Sie es später noch einmal.",
+  "VPNORPROXYDETECTED": "Dieser Inhalt ist mit VPN oder Proxy nicht abspielbar.",
   "UNKNOWN": "Dieser Inhalt ist nicht verfügbar."
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -7,5 +7,6 @@
   "JOURNALISTIC": "This content is temporarily unavailable for journalistic reasons.",
   "LEGAL": "This content is not available due to legal restrictions.",
   "STARTDATE": "This content is not available yet.",
+  "VPNORPROXYDETECTED": "This content cannot be played while using a VPN or a proxy.",
   "UNKNOWN": "This content is not available."
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -7,5 +7,6 @@
   "JOURNALISTIC": "Ce contenu est temporairement indisponible pour des raisons éditoriales.",
   "LEGAL":"Pour des raisons juridiques, ce contenu n'est pas disponible.",
   "STARTDATE":"Ce contenu n'est pas encore disponible. Veuillez réessayer plus tard.",
+  "VPNORPROXYDETECTED": "Ce contenu ne peut pas être lu avec un VPN ou un proxy.",
   "UNKNOWN":"Ce contenu n'est actuellement pas disponible."
 }

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -7,5 +7,6 @@
   "JOURNALISTIC": "Questo contenuto è temporaneamente non disponibile per motivi editoriali.",
   "LEGAL":"Il contenuto non è fruibile a causa di restrizioni legali.",
   "STARTDATE":"Il contenuto non è ancora disponibile. Per cortesia prova più tardi.",
+  "VPNORPROXYDETECTED": "Questo contenuto non può essere riprodotto con VPN o proxy.",
   "UNKNOWN":"Questo media non è disponibile."
 }

--- a/src/lang/rm.json
+++ b/src/lang/rm.json
@@ -90,5 +90,6 @@
   "JOURNALISTIC": "Quest cuntegn na stat ad interim betg a disposiziun per motivs publicistics.",
   "LEGAL": "Quest cuntegn n'è betg disponibel perquai ch'el è scadì.",
   "STARTDATE": "Quest cuntegn n'è betg anc disponibel. Empruvai pli tard.",
+  "VPNORPROXYDETECTED": "Quest cuntegn na po betg vegnir reproducì cun VPN ni proxy activà.",
   "UNKNOWN": "Quest cuntegn n'è betg disponibel."
 }


### PR DESCRIPTION
## Description

Resolves #311 by introducing a new blocking reason, `VPNPROXYDETECTED`, which will be displayed by the player whenever a VPN or proxy is detected by the backend. This will apply to content protected by DRM as well as certain live events.

## Changes made

- add translations for the new blocking reason
