### PR TITLE
fix(layout): progress bar displayed in tiny/x-small on live stream without DVR

### DIFF
--- a/scss/components/_layout.scss
+++ b/scss/components/_layout.scss
@@ -60,8 +60,10 @@
 ******************************************************************************
 */
 // Avoid hiding the progress control
-&.vjs-layout-tiny,
-&.vjs-layout-x-small {
+&.vjs-layout-tiny:not(.vjs-live),
+&.vjs-layout-x-small:not(.vjs-live),
+&.vjs-layout-tiny.vjs-liveui,
+&.vjs-layout-x-small.vjs-liveui {
   .vjs-progress-control {
     display: flex;
   }


### PR DESCRIPTION
## Description

When the player is resized to `vjs-layout-tiny` or `vjs-layout-x-small` while a live stream without DVR is being played, the progress bar appears even though it shouldn't.


https://github.com/user-attachments/assets/db38eb9e-f185-437a-a789-063d9046af25



## Changes made

- update display rules to ensure the progress bar is only shown for VOD and live streams with DVR.

