### PR TITLE
fix(media-composition): remove chapters if the media is not type of EPISODE

### DIFF
--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -86,8 +86,10 @@ class MediaComposition {
    */
   getChapters() {
     const AUDIO = 'AUDIO';
+    const EPISODE = 'EPISODE';
 
-    if (this.getMainChapter().mediaType === AUDIO) return [];
+    if (this.getMainChapter().mediaType === AUDIO ||
+    this.getMainChapter().type !== EPISODE) return [];
 
     return this.chapterList.filter(({ mediaType }) => mediaType !== AUDIO);
   }

--- a/test/__mocks__/urn:schedule:live:stream:chapters.json
+++ b/test/__mocks__/urn:schedule:live:stream:chapters.json
@@ -1,0 +1,130 @@
+{
+  "chapterUrn": "urn:rts:video:_rts_info_fulldvr",
+  "chapterList": [
+    {
+      "id": "_rts_info_fulldvr",
+      "mediaType": "VIDEO",
+      "vendor": "RTS",
+      "urn": "urn:rts:video:_rts_info_fulldvr",
+      "title": "⚽️ LiveCenter FullDVR (live for 76 seconds)",
+      "description": "⚽️ LiveCenter FullDVR",
+      "imageUrl": "https://www.rts.ch/2017/08/28/11/22/8872025.image/16x9",
+      "type": "SCHEDULED_LIVESTREAM",
+      "date": "2025-05-19T08:47:00Z",
+      "duration": 120030,
+      "validFrom": "2025-05-19T08:47:00Z",
+      "validTo": "2025-05-19T08:49:00Z",
+      "position": 0,
+      "noEmbed": false,
+      "playableAbroad": false,
+      "displayable": true,
+      "markIn": 0,
+      "markOut": 1,
+      "aspectRatio": "16:9",
+      "resourceList": [
+        {
+          "url": "https://srgssrch.akamaized.net/hls/live/2022077/srgssr-hls-stream20-ch-dvr/master.m3u8?dw=7200?start=1747644390",
+          "quality": "HD",
+          "protocol": "HLS",
+          "encoding": "H264",
+          "mimeType": "application/x-mpegURL",
+          "presentation": "DEFAULT",
+          "streaming": "HLS",
+          "dvr": true,
+          "live": true,
+          "mediaContainer": "UNKNOWN",
+          "audioCodec": "AAC",
+          "tokenType": "AKAMAI",
+          "videoCodec": "H264",
+          "audioTrackList": [
+            { "locale": "mis", "language": "Uncoded language", "source": "HLS" }
+          ],
+          "analyticsData": { "srg_mqual": "HD", "srg_mpres": "DEFAULT" },
+          "analyticsMetadata": {
+            "media_streaming_quality": "HD",
+            "media_special_format": "DEFAULT"
+          }
+        }
+      ],
+      "analyticsData": {
+        "ns_st_ep": "\uD83C\uDDE8\uD83C\uDDED RTSInfo (live with DVR)",
+        "ns_st_ty": "Video",
+        "ns_st_ci": "_rts_info"
+      },
+      "analyticsMetadata": {
+        "media_segment": "\uD83C\uDDE8\uD83C\uDDED RTSInfo (live with DVR)",
+        "media_type": "Video",
+        "media_segment_id": "_rts_info",
+        "media_urn": "urn:rts:video:_rts_info"
+      }
+    },
+    {
+      "id": "_rts_info_fulldvr_segment1",
+      "mediaType": "VIDEO",
+      "urn": "urn:rts:video:_rts_info_fulldvr_segment1",
+      "title": "Highlight 1",
+      "imageUrl": "https://www.rts.ch/2017/08/28/11/22/8872025.image/16x9",
+      "type": "CLIP",
+      "duration": 10000,
+      "validFrom": "2025-05-19T08:47:00Z",
+      "validTo": "2025-05-19T08:50:00Z",
+      "fullLengthUrn": "urn:rts:video:_rts_info_fulldvr",
+      "position": 0,
+      "noEmbed": false,
+      "playableAbroad": false,
+      "displayable": true,
+      "markIn": -10000,
+      "markOut": 0,
+      "resourceList": [
+        {
+          "url": "https://srgssrch.akamaized.net/hls/live/2022077/srgssr-hls-stream20-ch-dvr/master.m3u8?dw=7200?start=1747644390?start=1747644410&end=1747644420",
+          "quality": "HD",
+          "protocol": "HLS",
+          "encoding": "H264",
+          "mimeType": "application/x-mpegURL",
+          "streaming": "HLS",
+          "dvr": false,
+          "live": false,
+          "tokenType": "AKAMAI"
+        }
+      ]
+    },
+    {
+      "id": "_rts_info_fulldvr_segment2",
+      "mediaType": "VIDEO",
+      "urn": "urn:rts:video:_rts_info_fulldvr_segment2",
+      "title": "Highlight 2",
+      "imageUrl": "https://www.rts.ch/2017/08/28/11/22/8872025.image/16x9",
+      "type": "CLIP",
+      "duration": 10000,
+      "validFrom": "2025-05-19T08:47:00Z",
+      "validTo": "2025-05-19T08:50:00Z",
+      "fullLengthUrn": "urn:rts:video:_rts_info_fulldvr",
+      "position": 1,
+      "noEmbed": false,
+      "playableAbroad": false,
+      "displayable": true,
+      "markIn": 10000,
+      "markOut": 20000,
+      "resourceList": [
+        {
+          "url": "https://srgssrch.akamaized.net/hls/live/2022077/srgssr-hls-stream20-ch-dvr/master.m3u8?dw=7200?start=1747644390?start=1747644430&end=1747644440",
+          "quality": "HD",
+          "protocol": "HLS",
+          "encoding": "H264",
+          "mimeType": "application/x-mpegURL",
+          "streaming": "HLS",
+          "dvr": false,
+          "live": false,
+          "tokenType": "AKAMAI"
+        }
+      ]
+    }
+  ],
+  "analyticsData": {
+    "ns_st_pr": "\uD83C\uDDE8\uD83C\uDDED RTSInfo (live with DVR)"
+  },
+  "analyticsMetadata": {
+    "media_episode": "\uD83C\uDDE8\uD83C\uDDED RTSInfo (live with DVR)"
+  }
+}

--- a/test/dataProvider/model/MediaComposition.spec.js
+++ b/test/dataProvider/model/MediaComposition.spec.js
@@ -25,6 +25,8 @@ import * as urnUndefinedResourcelist from '../../__mocks__/urn:undefined:resourc
 import * as urnTimeIntervalList from '../../__mocks__/urn:rts:video:10313496-credits.json';
 import * as urnForumVideoWithAnAudioChapter from '../../__mocks__/forum:video:with:an:audio:chapter.json';
 import * as urnForumAudioWithAVideoChapter from '../../__mocks__/forum:audio:with:an:video:chapter.json';
+import * as urnScheduleLiveStreamChapters from '../../__mocks__/urn:schedule:live:stream:chapters';
+
 
 describe('MediaComposition', () => {
   const mediaCompositionUrnAnalyticsData = Object.assign(
@@ -166,6 +168,11 @@ describe('MediaComposition', () => {
   const mediaCompositionUrnForumAudioWithAVideoChapter = Object.assign(
     new MediaComposition(),
     urnForumAudioWithAVideoChapter
+  );
+
+  const mediaCompositionUrnScheduleLiveStreamChapters = Object.assign(
+    new MediaComposition(),
+    urnScheduleLiveStreamChapters
   );
 
   const DRMLIST = {
@@ -338,6 +345,10 @@ describe('MediaComposition', () => {
 
     it('should return an empty array when there is only audio chapters available', () => {
       expect(mediaCompositionUrnForumAudioWithAVideoChapter.getChapters()).toHaveLength(0);
+    });
+
+    it('should return an empty array when the chapter is not an EPISODE', () => {
+      expect(mediaCompositionUrnScheduleLiveStreamChapters.getChapters()).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #321, by removing chapters when the media type is not an episode. This follows the decision made during API discussion [#146](https://github.com/SRGSSR/pillarbox-documentation/issues/146#issuecomment-2883013095). Since Pillarbox lacks an automatic metadata update mechanism, removing chapters helps prevent confusion when a highlight is added during a live sports event.

Additionally, chapters in media types such as `EXTRACT`, `TRAILER`, and `CLIP` are considered a bug and should not be present.

## Changes made

- Remove chapters if the media is not an `EPISODE`
- Add a test case
