### PR TITLE
fix(github-actions): github page workflow

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -1,12 +1,14 @@
 name: Github Page
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Pre-release tag"]
+    types: [completed]
 
 jobs:
   github-page:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION




## Description
Fixes #309 when the player version number being always one version behind when a new version of the player, and thus the GitHub page, is released.
## Changes made
- Runs the `Github Page` workflow only when the `Pre-release tag` has completed successfully. This should ensure that the version property in the package.json file is up to date before the GitHub page is published.
