### PR TITLE
fix(pillarbox-monitoring): undefined getVideoPlaybackQuality

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -788,7 +788,7 @@ class PillarboxMonitoring {
     const { bitrate, url } = this.currentResource();
     const {
       droppedVideoFrames: frame_drops
-    } = this.player.getVideoPlaybackQuality();
+    } = this.player.getVideoPlaybackQuality() || {};
     const playback_duration = this.playbackDuration();
     const { position, position_timestamp } = this.playbackPosition();
     const stream_type = isFinite(this.player.duration()) ? 'On-demand' : 'Live';

--- a/test/trackers/pillarbox-monitoring.spec.js
+++ b/test/trackers/pillarbox-monitoring.spec.js
@@ -700,6 +700,8 @@ describe('PillarboxMonitoring', () => {
       player.currentSource.mockReturnValue({
         src: 'https://example.com/sd/player.m3u8'
       });
+      // tries to induce the error if getVideoPlaybackQuality is undefined
+      player.getVideoPlaybackQuality.mockReturnValueOnce(undefined);
       jest.spyOn(monitoring, 'playbackPosition').mockReturnValueOnce({
         position: 10,
         position_timestamp: jest.now() + 1000


### PR DESCRIPTION
## Description

In some cases, when a custom Tech is created, the return value of the function [`this.tech_[method]()`](https://github.com/videojs/video.js/blob/31f8d7ca102ba1a3bd62ef6b1dc8bd8f6e77719e/src/js/player.js#L2355
), where the value of `method` is `getVideoPlaybackQuality`, may be `undefined` for an undetermined reason during successive calls to the `getVideoPlaybackQuality` function. This causes an error to be thrown, preventing the monitoring data from being sent.

## Changes made

- add an empty object if `getVideoPlaybackQuality` is `undefined`
- update test case to try to induce error

