### PR TITLE
fix: exports.types in package.json for correct typescript entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./dist/pillarbox.es.js",
-      "require": "./dist/pillarbox.cjs"
+      "require": "./dist/pillarbox.cjs",
+      "types": "./dist/types/build.d.ts"
     },
     "./core": {
       "import": "./dist/pillarbox-core.es.js",


### PR DESCRIPTION
## Description

This PR fixes the TypeScript type resolution for `@srgssr/pillarbox-web`.
Previously, consumers saw the error:

> Could not find a declaration file for module '@srgssr/pillarbox-web' … this result could not be resolved when respecting package.json "exports".

The issue was caused by `package.json` using `"exports"` without exposing a `"types"` entry. As a result, TypeScript could not locate the bundled declaration files.

## Changes made

* Updated `package.json` to explicitly include `"types"` in the `exports["."]` entry.
* Ensured that `./dist/types/build.d.ts` is correctly exposed to TypeScript consumers.
* Left existing `import` and `require` exports untouched.
