### PR TITLE
fix(npm): drm playback on safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.23.1",
       "license": "MIT",
       "dependencies": {
-        "videojs-contrib-eme": "5.5.1"
+        "videojs-contrib-eme": "5.5.2"
       },
       "devDependencies": {
         "@babel/core": "^7.24.1",
@@ -21850,9 +21850,9 @@
       }
     },
     "node_modules/videojs-contrib-eme": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-5.5.1.tgz",
-      "integrity": "sha512-bDmypFzeKcyykpz+CNv4dK/XpqZ64LcgcFRV93n36h6vd3vtM1c3ECyXyxh8gdJrU7g6cEnPDgJCtj+q7y3mAw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-eme/-/videojs-contrib-eme-5.5.2.tgz",
+      "integrity": "sha512-hBSypwxAzabBOair1bV7PcHIPSxCIev3/DwD0DkP9B0RTYcvT7B7WpIQpwB12KgMTyf9F451h+iLD1uKhngyNg==",
       "license": "Apache-2.0",
       "dependencies": {
         "global": "^4.3.2"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "vite": "^5.4.10"
   },
   "dependencies": {
-    "videojs-contrib-eme": "5.5.1"
+    "videojs-contrib-eme": "5.5.2"
   },
   "peerDependencies": {
     "video.js": "^8.0.0"


### PR DESCRIPTION
## Description

Updating the `videojs-contrib-eme` package to the latest version fixes the playback issue on Safari for Macintosh devices.

This commit is marked as a fix and not as a chore in order to generate a new version of pillarbox.

It’s important to note that this commit does not fix the playback issue in Safari 
when switching from one DRM source to another on the same player instance. To fix 
that behavior, it will be necessary to upgrade to version v3.11.2. If that 
happens, the methods used to detect supported CDMs will no longer be available.

## Changes made

- update `videojs-contrib-eme` dependency




