### PR TITLE
feat(media-composition): expose spriteSheet property

### DIFF
--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -242,6 +242,7 @@ class MediaComposition {
       mimeType: resource.mimeType,
       presentation: resource.presentation,
       quality: resource.quality,
+      spriteSheet: this.getMainChapter().spriteSheet,
       streaming: resource.streaming,
       streamOffset: resource.streamOffset,
       subtitles: this.getFilteredExternalSubtitles(),


### PR DESCRIPTION
## Description 

Resolves #339 by exposing the `spriteSheet` property at the main resources level to improve the developer experience.

**Before**
```javascript
const {
    mediaData: {
        chapters: [{ spriteSheet }]
    }
} = player.currentSource();
```

**After**
```javascript
const {
    mediaData: {
        spriteSheet
    }
} = player.currentSource();
```

## Changes made

- expose the `spriteSheet` property


