### PR TITLE
test(player): mock undefined window.CSS.supports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -133,7 +133,9 @@ const config = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: [
+    './test/jest.setup.js'
+  ],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,0 +1,5 @@
+Object.defineProperty(window, 'CSS', {
+  configurable: true,
+  writable: true,
+  value: { supports: jest.fn() },
+});


### PR DESCRIPTION
## Description

When running unit tests the console was filled with error logs from an undefined method. Although the tests still passed, these unsolicited error messages cluttered the console.

Those errors appear to have started after this change in video.js: https://github.com/videojs/video.js/pull/8826

This produced logs like:

```
console.error
VIDEOJS: ERROR: TypeError: Cannot read properties of undefined (reading 'supports')
at TextTrackDisplay.updateDisplay (/home/rts/dev/pillarbox-web/node_modules/video.js/dist/video.cjs
.js:11455:41)
```

## Changes made

- create a `jest.setup.js` file to define a global mock for `window.CSS.supports`
