### PR TITLE
chore(github-actions): define working directory in the coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          working-directory: .


### PR DESCRIPTION
## Description

Setting the root directory to `.` should remove the error logs, as it will point to the `jest.config.js` file.

## Changes made

- set the `working-directory` to `.`

