### PR TITLE
feat(media-composition): add description to main resources

### DIFF
--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -230,6 +230,7 @@ class MediaComposition {
       blockedSegments: this.getMainBlockedSegments(),
       imageUrl: this.getMainChapterImageUrl(),
       chapters: this.getChapters(),
+      description: this.getMainChapter().description,
       drmList: resource.drmList,
       dvr: resource.dvr,
       eventData: this.getMainChapter().eventData,


### PR DESCRIPTION
## Description

Add the `description` field to the main resources, allowing the Chromecast receiver to use the `description` as a `subtitle`.

## Changes made

- `getMainResources` exposes the `description` field

