### PR TITLE
feat(log): add timestamps to videojs logs

### DIFF
--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -1,6 +1,7 @@
 import { version } from '../package.json';
 import videojs from 'video.js';
 import './components/player.js';
+import './utils/log.js';
 
 /**
  * Pillarbox is an alias for the video.js namespace with additional options.

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,0 +1,28 @@
+import videojs from 'video.js';
+
+/**
+ * Patch the built-in Video.js logger to prepend a local-timezone timestamp
+ * to every log message using a locale string to ensures timestamps align
+ * naturally with what the user sees on their device.
+ *
+ * The output is in swedish because the Swedish locale an ISO-like date format:
+ * `YYYY-MM-DD HH:mm:ss`.
+ */
+
+videojs.log = new Proxy(videojs.log, {
+  apply(target, thisArg, args) {
+    return target.apply(thisArg, [new Date().toLocaleString('sv'), ...args]);
+  },
+  get(target, prop, receiver) {
+    const value = Reflect.get(target, prop, receiver);
+
+    if (['debug', 'warn', 'error'].includes(prop) && typeof value === 'function') {
+      return function (...args) {
+        return value.call(target, new Date().toLocaleString('sv'), ...args);
+      };
+    }
+
+    return value;
+  }
+});
+

--- a/test/utils/log.spec.js
+++ b/test/utils/log.spec.js
@@ -1,0 +1,28 @@
+import videojs from 'video.js';
+import '../../src/utils/log.js';
+
+const expectedTimestampRegexp = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+
+describe('videojs logger patch', () => {
+  it('should prepend a locale timestamp to log', () => {
+    videojs.log('hello', 'world');
+
+    const [, timestamp, ...rest] = videojs.log.history().pop();
+
+    expect(typeof timestamp).toBe('string');
+    expect(timestamp).toMatch(expectedTimestampRegexp);
+    expect(rest).toEqual(['hello', 'world']);
+  });
+
+  ['debug', 'warn', 'error'].forEach(level => {
+    it(`should prepend a locale timestamp to ${level}`, () => {
+      videojs.log[level]('hello', 'world');
+
+      const [, , timestamp, ...rest] = videojs.log.history().pop();
+
+      expect(typeof timestamp).toBe('string');
+      expect(timestamp).toMatch(expectedTimestampRegexp);
+      expect(rest).toEqual(['hello', 'world']);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Resolves #317 by patching the built-in video.js logger and prepends a timestamp formatted using the user's local timezone.

This makes it easier to correlate issues with what the user actually experienced. The 'sv' locale is used because it provides an ISO-like format that stays readable for humans and easy to parse for the monitoring tools.