### PR TITLE
feat(monitoring): add played ranges to error and status events

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -287,8 +287,13 @@ class PillarboxMonitoring {
 
     this.sendEvent('ERROR', {
       audio,
-      log: JSON
-        .stringify(error.metadata || pillarbox.log.history().slice(-15)),
+      log: JSON.stringify(
+        error.metadata ||
+        {
+          history: pillarbox.log.history().slice(-15),
+          playedRanges: this.player.playedRanges()
+        }
+      ),
       message: error.message,
       name: PillarboxMonitoring.errorKeyCode(error.code),
       ...playbackPosition,
@@ -794,6 +799,7 @@ class PillarboxMonitoring {
     const stream_type = isFinite(this.player.duration()) ? 'On-demand' : 'Live';
     const stall = this.stallInfo();
     const subtitles = this.currentTextTrack();
+    const log = JSON.stringify({ playedRanges: this.player.playedRanges() });
 
     const data = {
       audio,
@@ -801,6 +807,7 @@ class PillarboxMonitoring {
       bitrate,
       buffered_duration,
       frame_drops,
+      log,
       playback_duration,
       position,
       position_timestamp,

--- a/test/__mocks__/player-mock.js
+++ b/test/__mocks__/player-mock.js
@@ -40,6 +40,7 @@ let playerMock = jest.fn(() => ({
   }),
   paused: jest.fn(),
   playbackRate: jest.fn().mockReturnValue(1),
+  playedRanges: jest.fn().mockReturnValue([]),
   on: jest.fn((evt, fn) => {
     if (!Array.isArray(evt)) {
       document.addEventListener(evt, fn);


### PR DESCRIPTION
## Description

Resolves #317 by providing played ranges information in monitoring status and error events, usign the `log` property.