### PR TITLE
feat(media-composition): add validFrom and validTo to main resources

### DIFF
--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -251,6 +251,8 @@ class MediaComposition {
       tokenType: resource.tokenType,
       url: resource.url,
       urn: this.chapterUrn,
+      validFrom: this.getMainValidFromDate(),
+      validTo: this.getMainValidToDate(),
       vendor: this.getMainChapter().vendor,
     }));
   }
@@ -286,20 +288,31 @@ class MediaComposition {
   /**
    * Compute a date from which this content is valid. Always return a date object.
    *
-   * @returns {Date} date specified in media composition or EPOCH when no date present.
+   * @returns {Date} date specified in media composition or undefined.
    */
   getMainValidFromDate() {
-    const mainChapter = this.getMainChapter();
+    const {
+      validFrom
+    } = this.getMainChapter() || {};
 
-    if (!mainChapter) {
-      return new Date(0);
-    }
+    if (!validFrom) return;
 
-    const { validFrom } = mainChapter;
+    return new Date(validFrom);
+  }
 
-    if (validFrom) {
-      return new Date(validFrom);
-    }
+  /**
+   * Compute a date to which this content is valid. Always return a date object.
+   *
+   * @returns {Date} date specified in media composition or undefined.
+   */
+  getMainValidToDate() {
+    const {
+      validTo
+    } = this.getMainChapter() || {};
+
+    if (!validTo) return;
+
+    return new Date(validTo);
   }
 
   /**

--- a/test/dataProvider/model/MediaComposition.spec.js
+++ b/test/dataProvider/model/MediaComposition.spec.js
@@ -497,7 +497,7 @@ describe('MediaComposition', () => {
 
   /**
    *****************************************************************************
-   * getMainValidDate **********************************************************
+   * getMainValidFromDate ******************************************************
    *****************************************************************************
    */
   describe('getMainValidFromDate', () => {
@@ -507,15 +507,40 @@ describe('MediaComposition', () => {
       );
     });
 
-    it('should return a currently valid date with empty mediaComposition', () => {
+    it('should return undefined if the mediaComposition does not contain a validFrom property', () => {
       expect(
-        mediaCompositionEmpty.getMainValidFromDate().getMilliseconds()
-      ).toBeLessThanOrEqual(new Date().getMilliseconds());
+        mediaCompositionUrnAnalyticsData.getMainValidFromDate()
+      ).toBeUndefined();
+    });
+
+    it('should return undefined if the mediaComposition is empty', () => {
+      expect(
+        mediaCompositionUrnEmptyChapters.getMainValidFromDate()
+      ).toBeUndefined();
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * getMainValidToDate ********************************************************
+   *****************************************************************************
+   */
+  describe('getMainValidToDate', () => {
+    it('should return a validTo date', () => {
+      expect(mediaCompositionUrnOneExternalSubtitle.getMainValidToDate()).toEqual(
+        new Date('2100-01-01T00:00:00+01:00')
+      );
     });
 
     it('should return undefined if the mediaComposition does not contain a validFrom property', () => {
       expect(
-        mediaCompositionUrnAnalyticsData.getMainValidFromDate()
+        mediaCompositionUrnAnalyticsData.getMainValidToDate()
+      ).toBeUndefined();
+    });
+
+    it('should return undefined if the mediaComposition is empty', () => {
+      expect(
+        mediaCompositionUrnEmptyChapters.getMainValidToDate()
       ).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Description

Adds the `validFrom` and `validTo` fields to the main resource, allowing you to create an experience around validity dates, such as a countdown timer.

## Changes made

- `getMainResources` exposes `validFrom` and `validTo` fields

