### PR TITLE
revert: tech reset on src call

### DIFF
--- a/docs/api/tutorials/Known Issues.md
+++ b/docs/api/tutorials/Known Issues.md
@@ -136,4 +136,30 @@ player.src({ src: 'urn:swi:video:48115940', type: 'srgssr/urn', disableTrackers:
    ```
    Again, in this scenario you MUST NOT re-enable the tracking for `trackedPlayer`.
 
+### Media keeps playing after an error occurs on loading a different source
+
+Under certain cases the internal call to `src_` reload logic is not triggered. As a result, the 
+previous media can continue playing in the background even though the new source failed to load.
+
+#### Issue Details
+
+- **Scenario:** An incompatible source error or a block reason when calling `player.src(...)` 
+- **Affected Browser:** All
+- **Symptoms:** Media keeps playing in the background.
+
+#### Solution
+
+To address this issue call instead `player.loadMedia(...)` when loading a different media. The 
+parameter is slightly different, please make sure you read the documentation: 
+[player.loadMedia][loadMedia], for example:
+
+```javascript
+// Use
+player.loadMedia({src:{src:'...', type:'...'}});
+
+// Instead of
+// player.src({src:'....', type:'...'});
+```
+
 [ios-bug]: https://bugs.webkit.org/show_bug.cgi?id=261512
+[loadMedia]: https://docs.videojs.com/player#loadMedia

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -164,25 +164,6 @@ class Player extends vjsPlayer {
   }
 
   /**
-   * Overrides the default `src` behavior to ensure the underlying tech is fully
-   * reset before setting a new source.
-   *
-   * This is a workaround for a Video.js issue where, under certain failure cases the
-   * internal `src_` reload logic is not triggered. As a result, the previous media
-   * can continue playing in the background even though the new source failed.
-   *
-   * @see https://docs.videojs.com/player#src
-   */
-  src(source) {
-    if (source) {
-      this.poster(null);
-      this.techCall_('reset');
-    }
-
-    super.src(source);
-  }
-
-  /**
    * A getter/setter for the media's text track.
    * Activates the text track according to the language and kind properties.
    * Falls back on the first text track found if the kind property is not satisfied.


### PR DESCRIPTION
## Description

Resetting the tech on the src call was causing problems with the eme support. We revert the change for the time being and added an articule on the known issues sections with a workaround that integrators can implement.

