### PR TITLE
feat(srgssr-middleware): initialize srgssr metadata text tracks by default

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -30,15 +30,7 @@ class SrgSsr {
    */
   static async addBlockedSegments(player, segments = []) {
     const trackId = 'srgssr-blocked-segments';
-    const removeTrack = player.textTracks().getTrackById(trackId);
-
-    if (removeTrack) {
-      player.textTracks().removeTrack(removeTrack);
-    }
-
     const segmentTrack = await SrgSsr.createTextTrack(player, trackId);
-
-    player.textTracks().addTrack(segmentTrack);
 
     if (!Array.isArray(segments) || !segments.length) return;
 
@@ -120,15 +112,7 @@ class SrgSsr {
    */
   static async addChapters(player, chapterUrn, chapters = []) {
     const trackId = 'srgssr-chapters';
-    const removeTrack = player.textTracks().getTrackById(trackId);
-
-    if (removeTrack) {
-      player.textTracks().removeTrack(removeTrack);
-    }
-
     const chapterTrack = await SrgSsr.createTextTrack(player, trackId);
-
-    player.textTracks().addTrack(chapterTrack);
 
     if (!Array.isArray(chapters) || !chapters.length) return;
 
@@ -147,15 +131,7 @@ class SrgSsr {
    */
   static async addIntervals(player, intervals = []) {
     const trackId = 'srgssr-intervals';
-    const removeTrack = player.textTracks().getTrackById(trackId);
-
-    if (removeTrack) {
-      player.textTracks().removeTrack(removeTrack);
-    }
-
     const intervalTrack = await SrgSsr.createTextTrack(player, trackId);
-
-    player.textTracks().addTrack(intervalTrack);
 
     if (!Array.isArray(intervals) || !intervals.length) return;
 
@@ -275,16 +251,24 @@ class SrgSsr {
   }
 
   /**
-   * Create a new metadata text track.
+   * Create a new metadata text track and add it to the player.
+   *
+   * If a text track with the same trackId exists, it is deleted beforehand.
    *
    * @param {Player} player
    * @param {String} trackId Text track unique ID
    *
    * @returns {Promise<TextTrack>}
    */
-  static createTextTrack(player, trackId) {
+  static async createTextTrack(player, trackId) {
+    const removeTrack = player.textTracks().getTrackById(trackId);
+
+    if (removeTrack) {
+      player.textTracks().removeTrack(removeTrack);
+    }
+
     // See https://github.com/videojs/video.js/issues/8519
-    return new Promise((resolve) => {
+    const textTrack = await new Promise((resolve) => {
       setTimeout(() => {
         resolve(new Pillarbox.TextTrack({
           id: trackId,
@@ -294,6 +278,10 @@ class SrgSsr {
         }));
       }, 100);
     });
+
+    player.textTracks().addTrack(textTrack);
+
+    return textTrack;
   }
 
   /**

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -119,8 +119,6 @@ describe('SrgSsr', () => {
     });
 
     it('Should add 2 blocked segments', async () => {
-      jest.useFakeTimers();
-
       const result = [];
 
       Pillarbox.TextTrack
@@ -128,7 +126,7 @@ describe('SrgSsr', () => {
         .addCue
         .mockImplementation((cue) => result.push(cue));
 
-      SrgSsr.addBlockedSegments(player, [{
+      await SrgSsr.addBlockedSegments(player, [{
         blockReason: 'GEOBLOCK',
         markIn: 10_0000,
         markOut: 25_0000
@@ -145,9 +143,7 @@ describe('SrgSsr', () => {
         markOut: 70_0000
       }]);
 
-      jest.advanceTimersByTime(100);
-
-      expect(await result).toHaveLength(2);
+      expect(result).toHaveLength(2);
     });
   });
 
@@ -210,8 +206,6 @@ describe('SrgSsr', () => {
     });
 
     it('should add all chapters that are not the main chapter', async () => {
-      jest.useFakeTimers();
-
       const chapterUrn = 'urn:full:length';
       const result = [];
 
@@ -220,7 +214,7 @@ describe('SrgSsr', () => {
         .addCue
         .mockImplementation((cue) => result.push(cue));
 
-      SrgSsr.addChapters(player, chapterUrn, [{
+      await SrgSsr.addChapters(player, chapterUrn, [{
         fullLengthMarkIn: 0,
         fullLengthMarkOut: 10000
       }, {
@@ -233,9 +227,7 @@ describe('SrgSsr', () => {
         fullLengthMarkOut: 9500
       }]);
 
-      jest.advanceTimersByTime(100);
-
-      expect(await result).toHaveLength(2);
+      expect(result).toHaveLength(2);
       expect(result[0].startTime).toBe(2.5);
       expect(result[0].endTime).toBe(5);
       expect(result[1].startTime).toBe(6);
@@ -280,8 +272,6 @@ describe('SrgSsr', () => {
     });
 
     it('should add intervals to the player', async () => {
-      jest.useFakeTimers();
-
       const result = [];
 
       Pillarbox.TextTrack
@@ -289,7 +279,7 @@ describe('SrgSsr', () => {
         .addCue
         .mockImplementation((cue) => result.push(cue));
 
-      SrgSsr.addIntervals(player, [{
+      await SrgSsr.addIntervals(player, [{
         markIn: 1_000,
         markOut: 2_000,
         type: 'OPENING_CREDITS'
@@ -299,9 +289,7 @@ describe('SrgSsr', () => {
         type: 'CLOSING_CREDITS'
       }]);
 
-      jest.advanceTimersByTime(100);
-
-      expect(await result).toHaveLength(2);
+      expect(result).toHaveLength(2);
       expect(JSON.parse(result[0].text).type).toBe('OPENING_CREDITS');
       expect(JSON.parse(result[1].text).type).toBe('CLOSING_CREDITS');
     });


### PR DESCRIPTION
## Description

Initialize text tracks linked to `chapters`, `intervals`, and `blocked segments` by default when playing a SRG SSR content. This lets developers dynamically add `VTTCue` objects to the selected track without having to create the track beforehand.

One use case would be, for example, a live event where the media metadata is continuously updated and chapters may be added dynamically.

Usage:

```javascript
// ... player initialization
// ... load SRG SSR media

player.textTracks().getTrackById('srgssr-blocked-segments').addCue(
  new VTTCue(
      69,
      420,
      JSON.stringify({
        //... data
      })
  )
);
player.textTracks().getTrackById('srgssr-chapters').addCue(
  new VTTCue(
      910,
      914,
      JSON.stringify({
        //... data
      })
  )
);
player.textTracks().getTrackById('srgssr-intervals').addCue(
  new VTTCue(
      0,
      9,
      JSON.stringify({
        //... data
      })
  )
);
```

## Changes made

- `srgssr.js`
  - update `addBlockedSegments` so the track is created regardless if data is provided
  - update `addChapters` so the track is created regardless if data is provided
  - update `addIntervals` so the track is created regardless if data is provided
- `srgssr.spec.js`
  - add test cases to verify the track is created regardless if data is provided
  - update test cases to verify that no `VTTCue` is created if conditions are not met

### Refactor

Consolidate the creation and removal of the text track into the `createTextTrack` 
method to simplifie the code.

- remove redundant code in `addBlockedSegments`
- remove redundant code in `addChapters`
- remove redundant code in `addIntervals`
- update test cases use `async/await` instead of manual timer manipulation
