### PR TITLE
feat(srgssr-middleware): add SRG SSR cues to text track as soon as possible

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -30,17 +30,9 @@ class SrgSsr {
    */
   static async addBlockedSegments(player, segments = []) {
     const trackId = 'srgssr-blocked-segments';
-    const segmentTrack = await SrgSsr.createTextTrack(player, trackId);
+    const blockedSegmentsToAdd = SrgSsr.getBlockedSegments(segments);
 
-    if (!Array.isArray(segments) || !segments.length) return;
-
-    const blockedSegments = segments.filter(segment => segment.blockReason);
-
-    if (!blockedSegments.length) return;
-
-    blockedSegments.forEach(segment => {
-      SrgSsr.addTextTrackCue(segmentTrack, segment);
-    });
+    await SrgSsr.createTextTrack(player, trackId, blockedSegmentsToAdd);
   }
 
   /**
@@ -91,6 +83,24 @@ class SrgSsr {
   }
 
   /**
+   * Add a new cues to a text track with the given array.
+   *
+   * @param {TextTrack} textTrack
+   * @param {Array.<
+   *   Segment |
+   *   Chapter |
+   *   TimeInterval>
+   * } cues SRG SSR's cues-like representation
+   */
+  static addTextTrackCues(textTrack, cues = []) {
+    if (!Array.isArray(cues)) return;
+
+    cues.forEach(cue => {
+      SrgSsr.addTextTrackCue(textTrack, cue);
+    });
+  }
+
+  /**
    * Add multiple text tracks to the player.
    *
    * @param {Player} player
@@ -112,15 +122,9 @@ class SrgSsr {
    */
   static async addChapters(player, chapterUrn, chapters = []) {
     const trackId = 'srgssr-chapters';
-    const chapterTrack = await SrgSsr.createTextTrack(player, trackId);
+    const chaptersToAdd = SrgSsr.getChapters(chapterUrn, chapters);
 
-    if (!Array.isArray(chapters) || !chapters.length) return;
-
-    chapters.forEach(chapter => {
-      if (chapterUrn !== chapter.fullLengthUrn) return;
-
-      SrgSsr.addTextTrackCue(chapterTrack, chapter);
-    });
+    await SrgSsr.createTextTrack(player, trackId, chaptersToAdd);
   }
 
   /**
@@ -131,13 +135,9 @@ class SrgSsr {
    */
   static async addIntervals(player, intervals = []) {
     const trackId = 'srgssr-intervals';
-    const intervalTrack = await SrgSsr.createTextTrack(player, trackId);
+    const instervalsToAdd = SrgSsr.getIntervals(intervals);
 
-    if (!Array.isArray(intervals) || !intervals.length) return;
-
-    intervals.forEach(interval => {
-      SrgSsr.addTextTrackCue(intervalTrack, interval);
-    });
+    await SrgSsr.createTextTrack(player, trackId, instervalsToAdd);
   }
 
   /**
@@ -257,10 +257,15 @@ class SrgSsr {
    *
    * @param {Player} player
    * @param {String} trackId Text track unique ID
+   * @param {Array.<
+   *   Segment |
+   *   Chapter |
+   *   TimeInterval>
+   * } cues SRG SSR's cues-like representation
    *
    * @returns {Promise<TextTrack>}
    */
-  static async createTextTrack(player, trackId) {
+  static async createTextTrack(player, trackId, cues = []) {
     const removeTrack = player.textTracks().getTrackById(trackId);
 
     if (removeTrack) {
@@ -278,6 +283,8 @@ class SrgSsr {
         }));
       }, 100);
     });
+
+    SrgSsr.addTextTrackCues(textTrack, cues);
 
     player.textTracks().addTrack(textTrack);
 
@@ -422,6 +429,47 @@ class SrgSsr {
       currentTime < blockedSegment.endTime;
 
     return isBlocked ? blockedSegment : undefined;
+  }
+
+  /**
+   * Get blocked segments.
+   *
+   * @param {Player} player
+   * @param {Array<Segment>} [segments=[]]
+   *
+   * @returns {Array<Segment>}
+   */
+  static getBlockedSegments(segments = []) {
+    if (!Array.isArray(segments) || !segments.length) return [];
+
+    return segments.filter(segment => segment.blockReason);
+  }
+
+  /**
+   * Get chapters related to the main chapter.
+   *
+   * @param {string} chapterUrn The URN of the main chapter.
+   * @param {Array.<Chapter>} [chapters=[]]
+   *
+   * @returns {Array.<Chapter>}
+   */
+  static getChapters(chapterUrn, chapters = []) {
+    if (!Array.isArray(chapters) || !chapters.length) return [];
+
+    return chapters.filter(chapter => chapterUrn === chapter.fullLengthUrn);
+  }
+
+  /**
+   * Get intervals.
+   *
+   * @param {Array<TimeInterval>} [segments=[]]
+   *
+   * @returns {Array<TimeInterval>}
+   */
+  static getIntervals(intervals = []) {
+    if (!Array.isArray(intervals) || !intervals.length) return [];
+
+    return intervals;
   }
 
   /**


### PR DESCRIPTION
## Description

Allows SRG SSR `cues` to be made available as soon as the text track is added to the `player.` This lets retrieve the `cues` as soon as the `addtrack` event is emitted.

## Changes made

- add `getChapters`, `getBlockedSegments`, `getIntervals`, `addTextTrackCues`
- update `addChapters`, `addBlockedSegments`, `addIntervals` to use the newly created methods
- update `createTextTrack` by adding a parameter that allows adding the `cues` to the track before it is passed to the `player`
- add `addTextTrackCues` test cases
- add `createTextTrack` test cases
- add `getBlockedSegments` test cases
- add `getChapters` test cases
- add `getIntervals` test cases

