### PR TITLE
feat(srgssr-middleware): set VTTCue id from data.urn when present

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -74,12 +74,14 @@ class SrgSsr {
       ? data.markIn : data.fullLengthMarkIn) / 1_000;
     const endTime = (Number.isFinite(data.markOut)
       ? data.markOut : data.fullLengthMarkOut) / 1_000;
+    const text = JSON.stringify(data);
+    const cue = new VTTCue(startTime, endTime, text);
 
-    textTrack.addCue(new VTTCue(
-      startTime,
-      endTime,
-      JSON.stringify(data)
-    ));
+    if (data.urn) {
+      cue.id = data.urn;
+    }
+
+    textTrack.addCue(cue);
   }
 
   /**

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -352,6 +352,59 @@ describe('SrgSsr', () => {
 
   /**
    *****************************************************************************
+   * addTextTrackCue ***********************************************************
+   *****************************************************************************
+   */
+
+  describe('addTextTrackCue', () => {
+    it('should have and empty an ID if there is not URN', () => {
+      const data = {
+        markIn: 0,
+        markOut: 0,
+      };
+      const result = [];
+
+
+      Pillarbox.TextTrack
+        .prototype
+        .addCue
+        .mockImplementation((cue) => result.push(cue));
+
+      const textTrack = new Pillarbox.TextTrack();
+
+      SrgSsr.addTextTrackCue(textTrack, data);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty('id');
+      expect(result[0].id).toBe('');
+    });
+
+    it('should contain an ID if there is an URN', () => {
+      const data = {
+        urn: 'urn:1',
+        markIn: 0,
+        markOut: 0,
+      };
+      const result = [];
+
+
+      Pillarbox.TextTrack
+        .prototype
+        .addCue
+        .mockImplementation((cue) => result.push(cue));
+
+      const textTrack = new Pillarbox.TextTrack();
+
+      SrgSsr.addTextTrackCue(textTrack, data);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty('id');
+      expect(result[0].id).toBe(data.urn);
+    });
+  });
+
+  /**
+   *****************************************************************************
    * addTextTrackCues **********************************************************
    *****************************************************************************
    */
@@ -975,7 +1028,7 @@ describe('SrgSsr', () => {
    *****************************************************************************
    */
   describe('getIntervals', () => {
-    it('should return an empty array when intervals parameter is omitted',  () => {
+    it('should return an empty array when intervals parameter is omitted', () => {
       expect(SrgSsr.getIntervals()).toHaveLength(0);
     });
 


### PR DESCRIPTION
## Description

Use the provided URN as the cue id so cues are identifiable when data includes an urn. This change will allow to update a cue in case there is any change.

Usage:

```javascript
const cue = player
            .textTracks()
            .getTrackById('srgssr-chapters')
            .cues
            .getCueById('urn:swisstxt:video:srf:1832602');

// assuming the cue exists update the start time
cue.startTime = 69;
```

## Changes made

- add a condition to set the id if the date contains an URN
- add test cases

