### PR TITLE
feat(srg-analytics): allow passing analytics env via SRG specific opts

### DIFF
--- a/docs/api/tutorials/Options.md
+++ b/docs/api/tutorials/Options.md
@@ -158,3 +158,20 @@ ensure proper media playback.
 
 > The absence of a conforming object from the server may lead to unexpected errors, affecting video
 > playback.
+
+### `srgOptions.analyticsEnvironment`
+
+***Specific to analytics of SRG SSR.***
+
+Specifies the environment use for SRG analytics/tracking. Is internally mapped to `navigation_environment` variable for the TagCommander data layer. If not set, `prod` is used.
+
+#### Usage
+
+```javascript
+const player = pillarbox('player', {
+  srgOptions: {
+    // Defines the analytics environment name
+    analyticsEnvironment: 'dev'
+  }
+});
+```

--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -640,6 +640,7 @@ class SrgSsr {
     if (!player.options().trackers.srgAnalytics) {
       const srgAnalytics = new SRGAnalytics(player, {
         debug: player.debug(),
+        environment: player.options().srgOptions.analyticsEnvironment,
         playerVersion: Pillarbox.VERSION.pillarbox,
         tagCommanderScriptURL:
           player.options().srgOptions.tagCommanderScriptURL,
@@ -739,6 +740,7 @@ Pillarbox.options.srgOptions = {
   dataProvider: undefined,
   dataProviderHost: undefined,
   dataProviderUrlHandler: undefined,
+  analyticsEnvironment: undefined,
   tagCommanderScriptURL: undefined,
 };
 

--- a/src/middleware/typedef.ts
+++ b/src/middleware/typedef.ts
@@ -65,6 +65,12 @@ export type SrgOptions = {
    */
   dataProviderUrlHandler: undefined | Function;
   /**
+   * The environment to use for SRG Analytics
+   *
+   * @defaultValue "prod"
+   */
+  analyticsEnvironment: undefined | string;
+  /**
    * The URL of the TagCommander script.
    */
   tagCommanderScriptURL: undefined | string;

--- a/src/trackers/SRGAnalytics.js
+++ b/src/trackers/SRGAnalytics.js
@@ -440,7 +440,7 @@ class SRGAnalytics {
    * - pos should be sent when the media player is in "play mode".
    * - once the video is paused or stopped, the timer for sending these actions must be stopped.
    *
-   * @see https://confluence.srg.beecollaboration.com/display/INTFORSCHUNG/standard+streaming+events%3A+sequence+of+events+for+media+player+actions#standardstreamingevents:sequenceofeventsformediaplayeractions-mandatoryplayerevents
+   * @see https://srgssr-ch.atlassian.net/wiki/spaces/INTFORSCHUNG/pages/795904171/standard+streaming+events+sequence+of+events+for+media+player+actions#mandatory-player-events
    */
   heartBeat() {
     this.heartBeatIntervalId = setInterval(() => {
@@ -779,7 +779,7 @@ class SRGAnalytics {
    * Sent to ComScore when the playback rate changes.
    *
    * @see https://github.com/SRGSSR/srgletterbox-web/issues/761
-   * @see https://jira.srg.beecollaboration.com/browse/ADI-256
+   * @see https://srgssr-ch.atlassian.net/browse/ADI-256 
    */
   rateChange() {
     this.notify('change_playback_rate');
@@ -876,11 +876,11 @@ class SRGAnalytics {
    * It's expected notifyBufferStart() to be called when the player starts buffering
    * and a call to notifyBufferStop() when content resumes after buffering.
    *
-   * @see Item 2: https://jira.srg.beecollaboration.com/browse/PLAY-2628
+   * @see Item 2: https://srgssr-ch.atlassian.net/browse/PLAY-2628 
    *
    * After the issue PLAYRTS-321
-   * @see Fix: https://jira.srg.beecollaboration.com/browse/PLAYRTS-321?focusedCommentId=201023&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-201023
-   * @see Fix: https://jira.srg.beecollaboration.com/browse/PLAYRTS-3065
+   * @see Fix: https://srgssr-ch.atlassian.net/browse/PLAYRTS-321?focusedCommentId=201023&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-201023
+   * @see Fix: https://srgssr-ch.atlassian.net/browse/PLAYRTS-3065
    */
   waiting() {
     if (!this.initialized || this.isWaiting) {

--- a/src/utils/Image.js
+++ b/src/utils/Image.js
@@ -27,7 +27,7 @@ class Image {
    * @property {String} [image.format=jpg] is the format of the image, default value jpg.
    * @property {String} [imageServiceUrl] Url of the image service that needs to comply with the specification defined by the IL.
    *
-   * @see https://confluence.srg.beecollaboration.com/pages/viewpage.action?spaceKey=SRGPLAY&title=Project+-+Image+Service
+   * @see https://srgssr-ch.atlassian.net/wiki/spaces/SRGPLAY/pages/799082429/Project+-+Image+Service
    *
    * @returns {String|undefined} the image scaling URL.
    */


### PR DESCRIPTION
## Description
The `navigation_environment` property used for TagCommander events was always defaulting to `prod`. 

## Changes made
This PR allows setting the `analyticsEnvironment` via the special `srgOptions` option, similarly how it works for the IL/data provider things. 

The documentation was also updated, to include the SRG analytics related special options.

Lastly, dead links to the old JIRA and Confluence instances were replaced with the current, working ones.
