### PR TITLE
ci(crowdin): add content write permission to download-crowdin workflow

### DIFF
--- a/.github/workflows/download-crowdin.yml
+++ b/.github/workflows/download-crowdin.yml
@@ -6,6 +6,7 @@ on:
     - cron: '0 */12 * * *'
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Description

The `download-crowdin` workflow needs content write permission to make changes to the language files.

