### PR TITLE
fix(srg-analytics): media_google_cast wrong value type

### DIFF
--- a/src/trackers/SRGAnalytics.js
+++ b/src/trackers/SRGAnalytics.js
@@ -418,7 +418,7 @@ class SRGAnalytics {
   getInternalLabels() {
     const data = {
       media_bu_distributer: this.srcMediaData.mediaData.vendor,
-      media_google_cast: this.player.tech(true).name() === 'PillarboxReceiver',
+      media_google_cast: (this.player.tech(true).name() === 'PillarboxReceiver').toString(),
       media_embedding_url: document.referrer,
       media_player_display: 'default', // TODO implement if it still relevant
       media_player_name: 'pillarbox-web', // TODO add a property playerName in the constructor with a default value ?


### PR DESCRIPTION
## Description

The value expected by Commander's Act is the string representation of the boolean value, not the boolean value itself.

## Changes made

- toString of the boolean value

