### PR TITLE
fix(srg-analytics): navigation_environment property not correctly initialized

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
       srgOptions: {
         dataProviderHost: ilHost,
         dataProviderUrlHandler: urlHandler,
+        analyticsEnvironment: 'dev',
       }
     });
 

--- a/src/trackers/SRGAnalytics.js
+++ b/src/trackers/SRGAnalytics.js
@@ -377,7 +377,6 @@ class SRGAnalytics {
       // TODO use media_is_dvr, media_is_live to define peach media_stream_type
       media_subtitles_on: this.isTextTrackEnabled(),
       media_volume: (this.player.volume() * 100).toFixed(0),
-      navigation_environment: this.environment,
     };
 
     if (this.isAudioTrackEnabled()) {
@@ -424,6 +423,7 @@ class SRGAnalytics {
       media_player_name: 'pillarbox-web', // TODO add a property playerName in the constructor with a default value ?
       media_player_version: this.playerVersion,
       media_url: this.srcMediaData.src,
+      navigation_environment: this.environment,
     };
     const analyticsMetadata =
       this.srcMediaData.mediaData.analyticsMetadata || {};


### PR DESCRIPTION
## Description

The `navigation_environment` property was not initialized correctly, which made it impossible to switch environments.

## Changes made

- set `navigation_environment` in the internal variables rather than in the event variables
- set test page environment to `dev`

