### PR TITLE
fix(pillarbox): remove ghost audio track on Chrome Linux

### DIFF
--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -39,15 +39,21 @@ pillarbox.options.fill = true;
  * Configuration options for HTML5 settings in Pillarbox.
  *
  * @see [VHS useForcedSubtitles Option]{@link https://github.com/videojs/http-streaming/blob/main/README.md#useforcedsubtitles}
+ * @see [VHS overrideNative Option]{@link https://github.com/videojs/http-streaming#overridenative}
  * @type {Object}
  * @property {Object} vhs - Configuration for the Video.js HTTP Streaming.
  * @property {boolean} useForcedSubtitles - Enables the player to display forced subtitles by default.
  * Forced subtitles are pieces of information intended for display when no other text representation
  * is selected. They are used to clarify dialogue, provide alternate languages, display texted graphics,
  * or present location/person IDs that are not otherwise covered in the dubbed/localized audio.
+ * @property {boolean} overrideNative - Try to use videojs-http-streaming even on platforms that
+ * provide some level of HLS support natively
  */
 pillarbox.options.html5 = {
-  vhs: { useForcedSubtitles: true }
+  vhs: {
+    useForcedSubtitles: true,
+    overrideNative: !pillarbox.browser.IS_SAFARI
+  }
 };
 /**
  * Configuration for the live tracker.

--- a/test/pillarbox.spec.js
+++ b/test/pillarbox.spec.js
@@ -21,9 +21,9 @@ describe('Pillarbox', () => {
       expect(pillarbox.options.enableSmoothSeeking).toBe(true);
     });
 
-    it('should set useForcedSubtitles to true in VHS configuration', () => {
+    it('should set useForcedSubtitles and overrideNative to true in VHS configuration', () => {
       expect(pillarbox.options.html5).toEqual({
-        vhs: { useForcedSubtitles: true }
+        vhs: { useForcedSubtitles: true, overrideNative: true }
       });
     });
 


### PR DESCRIPTION
## Description

Resolves [STXTBROAD-3094](https://srgssr-ch.atlassian.net/browse/STXTBROAD-3094) by removing the phantom audio track that appears on Chrome for Linux and causes issues when playing fragmented MP4 content over HLS or DASH.

## Changes made

- forces the use of MSE by setting the `overrideNative` property to `true` except on Safari
- update pillarbox options test case

## Hints

Refer to the comment https://srgssr-ch.atlassian.net/browse/STXTBROAD-3094?focusedCommentId=612052

[STXTBROAD-3094]: https://srgssr-ch.atlassian.net/browse/STXTBROAD-3094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ