### PR TITLE
fix(mediaComposition): empty main chapter fallback

### DIFF
--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -189,10 +189,6 @@ class MediaComposition {
       this.mainChapter = this.findChapterByUrn(this.chapterUrn);
     }
 
-    if (!this.mainChapter && this.chapterList && this.chapterList.length > 0) {
-      [this.mainChapter] = this.chapterList;
-    }
-
     return this.mainChapter;
   }
 

--- a/test/__mocks__/urn:blocked:chapter.json
+++ b/test/__mocks__/urn:blocked:chapter.json
@@ -1,4 +1,5 @@
 {
+  "chapterUrn": "urn:rts:video:10272382",
   "chapterList": [
     {
       "id": "10272382",

--- a/test/__mocks__/urn:main:chapter:missing.json
+++ b/test/__mocks__/urn:main:chapter:missing.json
@@ -1,0 +1,164 @@
+{
+  "chapterUrn": "urn:srf:video:7d96040b-28ca-47f9-b1bd-6222e7923e54",
+  "episode": {
+    "imageUrl": "https://download-media.srf.ch/world/image/audio/2020/12/917e4ef8986a460d94f3bd9e7139e6a9.jpg",
+    "imageTitle": "Tagesschau vom 03.05.2026: Hauptausgabe (löschen)",
+    "publishedDate": "2026-05-03T19:30:00+02:00",
+    "id": "2946dddd-1281-4099-ac63-336fb9712cb9",
+    "title": "Tagesschau vom 03.05.2026: Hauptausgabe (löschen)"
+  },
+  "show": {
+    "id": "ff969c14-c5a7-44ab-ab72-14d4c9e427a9",
+    "vendor": "SRF",
+    "transmission": "TV",
+    "urn": "urn:srf:show:tv:ff969c14-c5a7-44ab-ab72-14d4c9e427a9",
+    "title": "Tagesschau",
+    "lead": "Nationale und internationale Nachrichten vom Tag.",
+    "description": "Die «Tagesschau» berichtet über Themen aus Politik, Wirtschaft, Kultur, Sport, Gesellschaft und Wissenschaft aus dem In- und Ausland. ",
+    "imageUrl": "https://download-media.srf.ch/world/image/audio/2020/12/917e4ef8986a460d94f3bd9e7139e6a9.jpg",
+    "imageTitle": "Tagesschau",
+    "bannerImageUrl": "https://download-media.srf.ch/world/image/audio/2020/12/917e4ef8986a460d94f3bd9e7139e6a9.jpg",
+    "posterImageUrl": "https://download-media.srf.ch/world/image/audio/2023/04/96e8a418e34a466c861ef6cefd19defd.jpg",
+    "posterImageIsFallbackUrl": false,
+    "podcastImageUrl": "https://il.srgssr.ch/image-service/dynamic/f8a856c.jpg",
+    "podcastImageIsFallbackUrl": true,
+    "podcastFeedSdUrl": "https://www.srf.ch/feed/podcast/sd/ff969c14-c5a7-44ab-ab72-14d4c9e427a9.xml",
+    "podcastFeedHdUrl": "https://www.srf.ch/feed/podcast/hd/ff969c14-c5a7-44ab-ab72-14d4c9e427a9.xml",
+    "links": [
+      {
+        "link": "https://www.srf.ch/play/tv/sendung/tagesschau-spezial?id=c4b213cd-9790-0001-3063-e4001037ebe0",
+        "title": "Tagesschau Spezial"
+      }
+    ],
+    "primaryChannelId": "23FFBE1B-65CE-4188-ADD2-C724186C2C9F",
+    "primaryChannelUrn": "urn:srf:channel:tv:23FFBE1B-65CE-4188-ADD2-C724186C2C9F",
+    "numberOfEpisodes": 20246,
+    "topicList": [
+      {
+        "id": "a709c610-b275-4c0c-a496-cba304c36712",
+        "vendor": "SRF",
+        "transmission": "TV",
+        "urn": "urn:srf:topic:tv:a709c610-b275-4c0c-a496-cba304c36712",
+        "title": "News & Hintergründe",
+        "lead": "Hier finden Sie alle Sendungen von SRF zum Themenbereich News & Hintergründe: aktuell, informativ und tiefgründig.",
+        "description": "Tagesschau, Meteo, 10vor10, Schweiz aktuell, Börse, Kinder News, Forward, Arena, SRF Börse und viele mehr - die News- und Hintergrund-Sendungen von SRF stehen für seriös recherchierte Berichterstattung und kompetente Hintergrundberichterstattung.",
+        "imageUrl": "https://download-media.srf.ch/world/image/default/2025/08/blob-4",
+        "imageTitle": "News & Hintergründe"
+      }
+    ],
+    "allowIndexing": true
+  },
+  "channel": {
+    "id": "23FFBE1B-65CE-4188-ADD2-C724186C2C9F",
+    "vendor": "SRF",
+    "urn": "urn:srf:channel:tv:23FFBE1B-65CE-4188-ADD2-C724186C2C9F",
+    "title": "SRF 1",
+    "imageUrl": "https://download-media.srf.ch/world/image/audio/2015/07/74e9378315a24db285b8cf2e80b3d902.png",
+    "imageUrlRaw": "https://il.srgssr.ch/image-service/dynamic/536ef7.svg",
+    "imageTitle": "Logo",
+    "transmission": "TV"
+  },
+  "chapterList": [
+    {
+      "id": "f62365fa-17d1-49c7-8398-050dbe165bf6",
+      "mediaType": "VIDEO",
+      "vendor": "SRF",
+      "urn": "urn:srf:video:f62365fa-17d1-49c7-8398-050dbe165bf6",
+      "title": "Tagesschau vom 03.05.2026: Hauptausgabe (löschen)",
+      "lead": "FC Thun ist Schweizer Meister, Landsgemeinde Glarus: keine Redezeit-Beschränkung, Whatsapp-Konkurrent «Max»: Wanze zum Kreml, Shakira begeistert Millionen-Publikum an Copacabana",
+      "imageUrl": "https://download-media.srf.ch/world/image/video/2026/05/f62365fa-17d1-49c7-8398-050dbe165bf6-94s0ms.png",
+      "imageTitle": "Tagesschau vom 03.05.2026: Hauptausgabe (löschen)",
+      "blockReason": "LEGAL",
+      "type": "EPISODE",
+      "date": "2026-05-03T19:30:00+02:00",
+      "duration": 1376520,
+      "podcastSdUrl": "https://download-media.srf.ch/world/video/ts20/2026/05/ts20_20260503_201709_16852118_v_podcast_h264_q30.mp4",
+      "podcastHdUrl": "https://download-media.srf.ch/world/video/ts20/2026/05/ts20_20260503_201709_16852118_v_podcast_h264_q30.mp4",
+      "validFrom": "2026-05-03T19:30:00+02:00",
+      "playableAbroad": true,
+      "displayable": false,
+      "position": -1,
+      "noEmbed": false,
+      "analyticsData": {
+        "ns_st_ep": "Tagesschau vom 03.05.2026: Hauptausgabe (löschen)",
+        "ns_st_ci": "f62365fa-17d1-49c7-8398-050dbe165bf6",
+        "ns_st_cl": "1376520",
+        "ns_st_ct": "vc12"
+      },
+      "analyticsMetadata": {
+        "media_urn": "urn:srf:video:f62365fa-17d1-49c7-8398-050dbe165bf6",
+        "media_segment_length": "1377",
+        "media_episode_length": "1377",
+        "media_segment_id": "f62365fa-17d1-49c7-8398-050dbe165bf6",
+        "media_type": "Video",
+        "media_duration_category": "long",
+        "media_segment": "Tagesschau vom 03.05.2026: Hauptausgabe (löschen)",
+        "media_is_geoblocked": "false",
+        "media_joker1": "News & Hintergründe",
+        "media_sub_set_id": "EPISODE",
+        "media_topic_list": "urn:srf:topic:tv:a709c610-b275-4c0c-a496-cba304c36712",
+        "media_signlanguage_on": "false"
+      },
+      "aspectRatio": "16:9",
+      "spriteSheet": {
+        "urn": "urn:srf:video:f62365fa-17d1-49c7-8398-050dbe165bf6",
+        "rows": 23,
+        "columns": 20,
+        "thumbnailHeight": 84,
+        "thumbnailWidth": 150,
+        "interval": 3000,
+        "url": "https://il.srgssr.ch/spritesheet/urn/srf/video/f62365fa-17d1-49c7-8398-050dbe165bf6/sprite-f62365fa-17d1-49c7-8398-050dbe165bf6.jpeg"
+      },
+      "bannerImageUrl": "https://download-media.srf.ch/world/image/video/2026/05/f62365fa-17d1-49c7-8398-050dbe165bf6-94s0ms.png",
+      "bannerImageTitle": "Tagesschau vom 03.05.2026: Hauptausgabe (löschen)"
+    }
+  ],
+  "topicList": [
+    {
+      "id": "a709c610-b275-4c0c-a496-cba304c36712",
+      "vendor": "SRF",
+      "transmission": "TV",
+      "urn": "urn:srf:topic:tv:a709c610-b275-4c0c-a496-cba304c36712",
+      "title": "News & Hintergründe",
+      "lead": "Hier finden Sie alle Sendungen von SRF zum Themenbereich News & Hintergründe: aktuell, informativ und tiefgründig.",
+      "description": "Tagesschau, Meteo, 10vor10, Schweiz aktuell, Börse, Kinder News, Forward, Arena, SRF Börse und viele mehr - die News- und Hintergrund-Sendungen von SRF stehen für seriös recherchierte Berichterstattung und kompetente Hintergrundberichterstattung.",
+      "imageUrl": "https://download-media.srf.ch/world/image/default/2025/08/blob-4",
+      "imageTitle": "News & Hintergründe"
+    }
+  ],
+  "analyticsData": {
+    "ns_st_pr": "Tagesschau vom 03.05.2026",
+    "ns_st_ddt": "2026-05-03",
+    "ns_st_tdt": "2026-05-03",
+    "ns_st_tm": "19:30",
+    "ns_st_tep": "3869173499582",
+    "ns_st_stc": "0866",
+    "ns_st_st": "SRF Online",
+    "ns_st_tpr": "ff969c14-c5a7-44ab-ab72-14d4c9e427a9"
+  },
+  "analyticsMetadata": {
+    "media_episode_id": "2946dddd-1281-4099-ac63-336fb9712cb9",
+    "media_tv_id": "3869173499582",
+    "media_show_id": "ff969c14-c5a7-44ab-ab72-14d4c9e427a9",
+    "media_show": "Tagesschau",
+    "media_episode": "Tagesschau vom 03.05.2026",
+    "media_is_livestream": "false",
+    "media_full_length": "partial",
+    "media_enterprise_units": "SRF",
+    "media_content_group": "News & Hintergründe",
+    "media_channel_id": "23FFBE1B-65CE-4188-ADD2-C724186C2C9F",
+    "media_channel_name": "SRF 1",
+    "media_since_publication_d": "3",
+    "media_since_publication_h": "87",
+    "media_thumbnail": "https://download-media.srf.ch/world/image/video/2026/05/7d96040b-28ca-47f9-b1bd-6222e7923e54-140s44ms.png",
+    "media_publication_date": "2026-05-03",
+    "media_publication_time": "19:30:00",
+    "media_publication_datetime": "2026-05-03T19:30:00+02:00",
+    "media_channel_cs": "0866",
+    "media_tv_date": "2026-05-03",
+    "media_tv_time": "19:30:00",
+    "media_is_web_only": "false",
+    "media_joker1": "News & Hintergründe",
+    "media_signlanguage_on": "false"
+  }
+}

--- a/test/__mocks__/urn:only:one:chapter.json
+++ b/test/__mocks__/urn:only:one:chapter.json
@@ -1,4 +1,5 @@
 {
+  "chapterUrn": "urn:rts:video:10272382",
   "chapterList": [
     {
       "id": "10272382",

--- a/test/dataProvider/model/MediaComposition.spec.js
+++ b/test/dataProvider/model/MediaComposition.spec.js
@@ -26,6 +26,7 @@ import * as urnTimeIntervalList from '../../__mocks__/urn:rts:video:10313496-cre
 import * as urnForumVideoWithAnAudioChapter from '../../__mocks__/forum:video:with:an:audio:chapter.json';
 import * as urnForumAudioWithAVideoChapter from '../../__mocks__/forum:audio:with:an:video:chapter.json';
 import * as urnScheduleLiveStreamChapters from '../../__mocks__/urn:schedule:live:stream:chapters';
+import * as urnMainChapterMissing from '../../__mocks__/urn:main:chapter:missing.json';
 
 
 describe('MediaComposition', () => {
@@ -175,6 +176,11 @@ describe('MediaComposition', () => {
     urnScheduleLiveStreamChapters
   );
 
+  const mediaCompositionUrnMainChapterMissing = Object.assign(
+    new MediaComposition(),
+    urnMainChapterMissing
+  );
+
   const DRMLIST = {
     drmList: [
       {
@@ -294,35 +300,6 @@ describe('MediaComposition', () => {
 
   /**
    *****************************************************************************
-   * getChapterImageUrl ********************************************************
-   *****************************************************************************
-   */
-  describe('getChapterImageUrl', () => {
-    it('should return the main chapter\'s image URL', () => {
-      expect(
-        mediaCompositionUrnChapterBadOrder.getMainChapterImageUrl()
-      ).toBeTruthy();
-      expect(
-        mediaCompositionUrnChapterBadOrder.getMainChapterImageUrl()
-      ).toEqual(
-        expect.stringContaining(
-          'https://www.rts.ch/2019/03/08/12/59/10272381.image/16x9'
-        )
-      );
-    });
-
-    it('should return undefined when the main chapter doesn\'t contain an image URL', () => {
-      expect(
-        mediaCompositionUrnMainChapterNoImageUrl.getMainChapterImageUrl()
-      ).toBeFalsy();
-      expect(
-        mediaCompositionUrnMainChapterNoImageUrl.getMainChapterImageUrl()
-      ).toBeUndefined();
-    });
-  });
-
-  /**
-   *****************************************************************************
    * getChapters ***************************************************************
    *****************************************************************************
    */
@@ -429,6 +406,10 @@ describe('MediaComposition', () => {
     it('should return undefined with empty mediacomposition', () => {
       expect(mediaCompositionEmpty.getMainChapter()).toBe(undefined);
     });
+
+    it('should return undefined when mediaComposition is missing its main chapter', () => {
+      expect(mediaCompositionUrnMainChapterMissing.getMainChapter()).toBe(undefined);
+    });
   });
 
   /**
@@ -437,15 +418,39 @@ describe('MediaComposition', () => {
    *****************************************************************************
    */
   describe('getMainChapterImageUrl', () => {
-    it('should return a the image url', () => {
+    it('should return undefined if the mediaComposition does not have a main chapter', () => {
       const imageUrl =
-        mediaCompositionUrnOnlyOneChapter.getMainChapterImageUrl();
+        mediaCompositionUrnMainChapterMissing.getMainChapterImageUrl();
 
-      expect(imageUrl).toBe('http://image.url/image');
+      expect(imageUrl).toBe(undefined);
     });
 
     it('should return undefined with empty mediacomposition', () => {
       expect(mediaCompositionEmpty.getMainChapterImageUrl()).toBe(undefined);
+    });
+
+    it('should return undefined when the main chapter doesn\'t contain an image URL', () => {
+      expect(
+        mediaCompositionUrnMainChapterNoImageUrl.getMainChapterImageUrl()
+      ).toBeFalsy();
+
+      expect(
+        mediaCompositionUrnMainChapterNoImageUrl.getMainChapterImageUrl()
+      ).toBeUndefined();
+    });
+
+    it('should return the main chapter\'s image URL', () => {
+      expect(
+        mediaCompositionUrnChapterBadOrder.getMainChapterImageUrl()
+      ).toBeTruthy();
+
+      expect(
+        mediaCompositionUrnChapterBadOrder.getMainChapterImageUrl()
+      ).toEqual(
+        expect.stringContaining(
+          'https://www.rts.ch/2019/03/08/12/59/10272381.image/16x9'
+        )
+      );
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #397 by removing the fallback that selected the first available chapter when the `mediaComposition` does not contain a main chapter.

As a result, the player no longer tries to display something in that case and now fails immediately. Below the `before`/`after` fix:

<img width="350" height="auto" alt="Before" src="https://github.com/user-attachments/assets/9fc51983-8cdf-41be-b798-e7aa9172e891" />
<img width="350" height="auto" alt="After" src="https://github.com/user-attachments/assets/9ed31e32-eea5-4ae2-a71b-5ec61f05a48e" />

_Note that a `mediaComposition` without a main chapter should never occur._

## Changes made

- remove the fallback that picked the first found chapter
- add the `chapterUrn` property to `urn:blocked:chapter.json` and `urn:only:one:chapter.json` to satisfy the new main chapter requirement
- add a new mock file containing `chapterUrn` but where the main chapter is missing
- remove `getChapterImageUrl` because the `MediaComposition` class does not have such a method
- adapt the `getMainChapterImageUrl` tests and reuse the test cases from `getChapterImageUrl` with adjustments
- add a test case in `getMainChapter`
