### PR TITLE
chore: re-run release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,12 +8,14 @@ on:
 jobs:
   publish-dist-tag:
     runs-on: ubuntu-latest
+    environment: npmjs
 
     permissions:
       packages: write
       issues: write
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Generate Token
@@ -52,7 +54,7 @@ jobs:
         run: npm run release:ci
         env:
           GITHUB_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Pre-release main tag failed 🫣
         if: failure()


### PR DESCRIPTION
## Description

This commit is intended only to trigger a new release so that a new tag can be promoted as a pre-release.

The reason is that during the previous release attempt, publishing the tag to npmjs failed due to a permissions issue with the token, which was no longer valid. See: https://github.com/SRGSSR/pillarbox-web/actions/runs/26148998346/attempts/1

## Changes made

- remove the tag `v1.35.0` in order to recreate a clean release using tag `v1.34.2` as the starting point.
- updates the pre-release workflow to configure a "Trusted Publisher" as 
recommended by npmjs.
  - https://docs.npmjs.com/trusted-publishers
  - https://docs.npmjs.com/generating-provenance-statements

