### PR TITLE
fix(monitoring): player null reference

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -489,7 +489,7 @@ class PillarboxMonitoring {
 
     // Calculate the position timestamp from the start date on Safari
     if (pillarbox.browser.IS_ANY_SAFARI) {
-      const startDate = Date.parse(this.player.$('video').getStartDate());
+      const startDate = Date.parse(this.player.tech(true).el().getStartDate());
 
       position_timestamp = !isNaN(startDate) ?
         (startDate + position) : undefined;


### PR DESCRIPTION
## Description

In Safari, `PillarboxMonitoring` retrieves the start date directly from the media element. However, access was limited to the `video` player, which meant that when the player was initialized with the `audio` tag, a null reference error was returned when calling `getStartDate`.

## Changes made

- use the `tech(true).el` to retrieve the media element
