### PR TITLE
feat: add DRM and HDCP detection support

### DIFF
--- a/src/components/drm-support.js
+++ b/src/components/drm-support.js
@@ -1,0 +1,180 @@
+import videojs from 'video.js';
+
+/** @import Component from 'video.js/dist/types/component' */
+/** @import Player from 'video.js/dist/types/player' */
+
+/**
+ * @ignore
+ * @type {typeof Component}
+ */
+const Component = videojs.getComponent('Component');
+
+/**
+ * A component that provides DRM support detection.
+ *
+ * @class DrmSupport
+ *
+ * @extends {Component}
+ */
+class DrmSupport extends Component {
+  /**
+   * Creates an instance of DrmSupport.
+   *
+   * @param {Player} player the player instance
+   * @param {Object} [options={}] the component options
+   */
+  constructor(player, options = {}) {
+    const opts = videojs.obj.merge(options, { createEl: false });
+
+    super(player, opts);
+  }
+
+  /**
+   * Checks DRM and HDCP capabilities.
+   *
+   * @param {Object} [options={}] configuration options
+   * @param {string} [options.contentType='video/mp4; codecs="avc1.42E01E"'] video content type to test
+   * @param {string[]} [options.initDataTypes=['cenc']] initialization data types
+   *
+   * @returns {Promise<Object>} object containing supported levels and HDCP per vendor
+   *
+   * @example
+   * player.drmSupport.check().then((results) => {
+   *   console.log('DRM Support Results:', results);
+   *   // Example output:
+   *   // {
+   *   //   widevine: { level: 'L1', hdcp: '2.2' },
+   *   //   playReady: null,
+   *   //   fairPlay: null,
+   *   //   clearKey: { level: 'Supported', hdcp: null }
+   *   // }
+   * });
+   *
+   * @example
+   * player.drmSupport().check({
+   *   contentType: 'video/mp4; codecs="avc1.4d401e"',
+   *   initDataTypes: ['cenc', 'keyids']
+   * }).then((results) => {
+   *   console.log('DRM Support Results:', results)
+   * });
+   */
+  async check({
+    contentType = 'video/mp4; codecs="avc1.42E01E"',
+    initDataTypes = ['cenc']
+  } = {}) {
+    const results = {};
+    const promises = Object.entries(DrmSupport.DRM_CONFIG).map(
+      async ([key, { vendor, levels }]) => {
+        results[key] =
+          await this.checkVendor(vendor, levels, initDataTypes, contentType);
+      }
+    );
+
+    await Promise.all(promises);
+
+    return results;
+  }
+
+  /**
+   * Tests robustness levels and HDCP for specific DRM vendor.
+   *
+   * @param {string} vendor key system identifier
+   * @param {Array<{robustness: string, label: string}>} levels array of robustness levels to test
+   * @param {string[]} initDataTypes initialization data types
+   * @param {string} contentType video content type
+   *
+   * @returns {Promise<{level: string, hdcp: string|null}|null>} supported level and HDCP or null
+   */
+  async checkVendor(vendor, levels, initDataTypes, contentType) {
+    for (const { robustness, label } of levels) {
+      try {
+        const config = [{
+          initDataTypes,
+          videoCapabilities: [{ contentType, robustness }]
+        }];
+
+        const access =
+          await navigator.requestMediaKeySystemAccess(vendor, config);
+        const mediaKeys = await access.createMediaKeys();
+        const hdcp = await this.findMaxHdcp(mediaKeys);
+
+        return { level: label, hdcp };
+      } catch (e) {
+        videojs.log.warn(
+          'DrmSupport',
+          `checkVendor failed (vendor=${vendor}, level=${label}, contentType=${contentType}, robustness=${robustness})`,
+          e
+        );
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Iterates through HDCP versions to find maximum supported version.
+   *
+   * @param {MediaKeys} mediaKeys instantiated MediaKeys object
+   *
+   * @returns {Promise<string|null>} maximum usable HDCP version or null
+   */
+  async findMaxHdcp(mediaKeys) {
+    if (!mediaKeys.getStatusForPolicy) {
+      return null;
+    }
+
+    const versions = ['2.3', '2.2', '2.1', '2.0', '1.4', '1.3', '1.2', '1.1', '1.0'];
+
+    for (const version of versions) {
+      const status = await mediaKeys
+        .getStatusForPolicy({ minHdcpVersion: version })
+        .catch(() => null);
+
+      if (status === 'usable') {
+        return version;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns static DRM configuration matrix.
+   *
+   * @returns {Object} DRM configuration
+   */
+  static get DRM_CONFIG() {
+    return {
+      widevine: {
+        vendor: 'com.widevine.alpha',
+        levels: [
+          { robustness: 'HW_SECURE_ALL', label: 'L1' },
+          { robustness: 'SW_SECURE_CRYPTO', label: 'L3' }
+        ]
+      },
+      playReady: {
+        vendor: 'com.microsoft.playready',
+        levels: [
+          { robustness: '3000', label: 'SL3000' },
+          { robustness: '2000', label: 'SL2000' }
+        ]
+      },
+      fairPlay: {
+        vendor: 'com.apple.fps',
+        levels: [
+          { robustness: '', label: 'Supported' }
+        ]
+      },
+      clearKey: {
+        vendor: 'org.w3.clearkey',
+        levels: [
+          { robustness: '', label: 'Supported' }
+        ]
+      }
+    };
+  }
+}
+
+videojs.registerComponent('DrmSupport', DrmSupport);
+
+export default DrmSupport;

--- a/src/pillarbox.js
+++ b/src/pillarbox.js
@@ -3,6 +3,7 @@ import videojs from 'video.js';
 import './components/player.js';
 import './components/audio-track-menu-item.js';
 import './components/picture-in-picture-toggle.js';
+import './components/drm-support.js';
 
 /**
  * Pillarbox is an alias for the video.js namespace with additional options.
@@ -20,6 +21,15 @@ pillarbox.VERSION = {
   eme: videojs.getPlugin('eme').VERSION,
 };
 
+/**
+ * Enable DrmSupport component by default.
+ *
+ * A component that provides DRM support detection.
+ *
+ * @type {boolean}
+ * @default true
+ */
+pillarbox.options.drmSupport = true;
 /**
  * Enable smooth seeking for Pillarbox.
  *

--- a/test/components/drm-support.spec.js
+++ b/test/components/drm-support.spec.js
@@ -1,0 +1,154 @@
+import pillarbox from '../../src/pillarbox.js';
+import DrmSupport from '../../src/components/drm-support.js';
+
+// Mock load to avoid having: Not implemented: HTMLMediaElement.prototype.load
+window.HTMLMediaElement.prototype.load = () => { /* noop */ };
+
+describe('DrmSupport', () => {
+  let videoEl;
+  let player;
+
+  pillarbox.log.warn = jest.fn().mockReturnValue({});
+
+  beforeAll(() => {
+    videoEl = document.createElement('video');
+    videoEl.id = 'player';
+
+    document.body.appendChild(videoEl);
+
+    player = new pillarbox('player');
+  });
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    window.navigator.requestMediaKeySystemAccess = jest.fn();
+  });
+
+  afterEach(() => {
+    if (!player) return;
+
+    player.dispose();
+  });
+
+  it('should be registered and attached to the player', () => {
+    expect(pillarbox.getComponent('DrmSupport')).toBe(DrmSupport);
+    expect(player.drmSupport).toBeInstanceOf(DrmSupport);
+  });
+
+  it('should set createEl to false by default', () => {
+    const DrmSupport = pillarbox.getComponent('DrmSupport');
+    const drmSupport = new DrmSupport(player);
+
+    expect(drmSupport.options().createEl).toBe(false);
+  });
+
+  it('should keep createEl option set to false', () => {
+    const DrmSupport = pillarbox.getComponent('DrmSupport');
+    const drmSupport = new DrmSupport(player, {
+      createEl: true
+    });
+
+    expect(drmSupport.options().createEl).toBe(false);
+  });
+
+  describe('checkVendor', () => {
+    const levels = [
+      { robustness: 'HIGH', label: 'L1' },
+      { robustness: 'LOW', label: 'L3' }
+    ];
+    const initTypes = ['cenc'];
+    const type = 'video/mp4';
+
+    it('should return level and hdcp for successful robustness', async () => {
+      const mockMediaKeys = {};
+      const mockAccess = { createMediaKeys: jest.fn().mockResolvedValue(mockMediaKeys) };
+
+      window.navigator.requestMediaKeySystemAccess.mockResolvedValue(mockAccess);
+
+      jest.spyOn(player.drmSupport, 'findMaxHdcp').mockResolvedValue('2.2');
+
+      const result = await player.drmSupport.checkVendor('test.drm', levels, initTypes, type);
+
+      expect(result).toEqual({ level: 'L1', hdcp: '2.2' });
+      expect(mockAccess.createMediaKeys).toHaveBeenCalledTimes(1);
+    });
+
+    it('should continue to next level if first fails', async () => {
+      const mockMediaKeys = {};
+      const mockAccess = { createMediaKeys: jest.fn().mockResolvedValue(mockMediaKeys) };
+
+      window.navigator
+        .requestMediaKeySystemAccess
+        .mockRejectedValueOnce(new Error('Fail HIGH'))
+        .mockResolvedValueOnce(mockAccess);
+
+      jest.spyOn(player.drmSupport, 'findMaxHdcp').mockResolvedValue('1.4');
+
+      const result = await player.drmSupport.checkVendor('test.drm', levels, initTypes, type);
+
+      expect(result).toEqual({ level: 'L3', hdcp: '1.4' });
+      expect(window.navigator.requestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return null if all levels fail', async () => {
+      window.navigator.requestMediaKeySystemAccess.mockRejectedValue(new Error('Fail'));
+
+      const result = await player.drmSupport.checkVendor('test.drm', levels, initTypes, type);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findMaxHdcp', () => {
+    it('should return null if getStatusForPolicy is missing', async () => {
+      const mediaKeys = {};
+      const result = await player.drmSupport.findMaxHdcp(mediaKeys);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return highest usable HDCP version', async () => {
+      const mediaKeys = {
+        getStatusForPolicy: jest.fn().mockImplementation(async ({ minHdcpVersion }) => {
+          if (minHdcpVersion === '2.3') {
+            throw new Error('Too high');
+          }
+
+          if (minHdcpVersion === '2.2') {
+            return 'usable';
+          }
+
+          return 'usable';
+        })
+      };
+
+      const result = await player.drmSupport.findMaxHdcp(mediaKeys);
+
+      expect(result).toBe('2.2');
+    });
+
+    it('should return null if no version is usable', async () => {
+      const mediaKeys = {
+        getStatusForPolicy: jest.fn().mockRejectedValue(new Error('Fail'))
+      };
+
+      const result = await player.drmSupport.findMaxHdcp(mediaKeys);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('check', () => {
+    it('should call checkVendor for all configs', async () => {
+      jest.spyOn(player.drmSupport, 'checkVendor').mockResolvedValue({ level: 'MockLabel', hdcp: '2.2' });
+
+      await player.drmSupport.check();
+
+      expect(player.drmSupport.checkVendor)
+        .toHaveBeenCalledTimes(
+          Object.keys(DrmSupport.DRM_CONFIG).length
+        );
+    });
+  });
+});


### PR DESCRIPTION
## Description

Resolves #410 by enabling the retrieval of information related to DRM security and the supported HDCP level, so that the best resource can be selected based on the client’s capabilities.

## Changes made

- add a new DrmSupport component
- enable DrmSupport component by default in Pillarbox
- add unit test cases

