### PR TITLE
feat(monitoring): add DRM info to START event

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -184,6 +184,26 @@ class PillarboxMonitoring {
   }
 
   /**
+   * Asynchronously retrieves the DRM capabilities of the player.
+   *
+   * ClearKey is filtered because we don't use it.
+   *
+   * @async
+   *
+   * @returns {Promise<Object|undefined>} a promise that resolves to an object
+   *                                      containing the supported DRM capabilities
+   */
+  async capabilities() {
+    if (!this.player.drmSupport) return;
+
+    const result = await this.player.drmSupport.check();
+
+    return Object.fromEntries(Object.entries(result)
+      .filter(([key, value]) => value !== null && key !== 'clearKey')
+      .map(([key, value]) => [key, value]));
+  }
+
+  /**
    * Gets the language of the current audio track.
    *
    * @returns {string|undefined} The language of the current audio track, or undefined if no audio track is available or if the language is not set.
@@ -271,8 +291,10 @@ class PillarboxMonitoring {
 
   /**
    * Handles player errors by sending an `ERROR` event, then resets the session.
+   *
+   * @async
    */
-  error() {
+  async error() {
     const audio = this.currentAudioTrack();
     const error = this.player.error();
     const playbackPosition = this.playbackPosition();
@@ -282,7 +304,7 @@ class PillarboxMonitoring {
     const subtitles = this.currentTextTrack();
 
     if (!this.player.hasStarted()) {
-      this.sendEvent('START', this.startEventData());
+      this.sendEvent('START', await this.startEventData());
     }
 
     this.sendEvent('ERROR', {
@@ -402,9 +424,11 @@ class PillarboxMonitoring {
   /**
    * Handles the session start by sending a `START` event immediately followed
    * by a `HEARTBEAT` when the `loadeddata` event is triggered.
+   *
+   * @async
    */
-  loadedData() {
-    this.sendEvent('START', this.startEventData());
+  async loadedData() {
+    this.sendEvent('START', await this.startEventData());
     this.sendEvent('HEARTBEAT', this.statusEventData());
     // starts the heartbeat interval
     this.heartbeat();
@@ -664,8 +688,10 @@ class PillarboxMonitoring {
    * @param {string} eventName Either START, STOP, ERROR, HEARTBEAT
    * @param {Object} [data={}] The payload object to be sent. Defaults to an
    *                           empty object if not provided
+   *
+   * @async
    */
-  sendEvent(eventName, data = {}) {
+  async sendEvent(eventName, data = {}) {
     // If the tracker is disabled for the current session, and there has been no
     // previous session, no event is sent. However, if a session was already
     // active, we still want to send the STOP event so that it is properly
@@ -836,9 +862,11 @@ class PillarboxMonitoring {
    * @property {PlayerCurrentDimensions} screen The current dimensions of the
    *                                            player.
    *
+   * @async
+   *
    * @returns {StartEventData} An object containing the start event data.
    */
-  startEventData() {
+  async startEventData() {
     const timestamp = PillarboxMonitoring.timestamp();
     // This avoids false subtraction results when loadStartTimestamp is not
     // initialized.
@@ -862,6 +890,7 @@ class PillarboxMonitoring {
 
     return {
       browser: PillarboxMonitoring.userAgent(),
+      capabilities: await this.capabilities(),
       device: { id: PillarboxMonitoring.deviceId() },
       media: this.mediaInfo(),
       player: this.playerInfo(),

--- a/test/trackers/pillarbox-monitoring.spec.js
+++ b/test/trackers/pillarbox-monitoring.spec.js
@@ -7,7 +7,7 @@ describe('PillarboxMonitoring', () => {
   let monitoring;
 
   global.navigator.sendBeacon = jest.fn();
-  global.window.MediaError = jest.fn().mockReturnValue({  });
+  global.window.MediaError = jest.fn().mockReturnValue({});
 
   beforeEach(() => {
     player = playerMock();
@@ -79,6 +79,34 @@ describe('PillarboxMonitoring', () => {
       player.buffered.mockReturnValue(pillarbox.time.createTimeRanges([[1, 70]]));
 
       expect(monitoring.bufferDuration()).toBe(69000);
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * capabilities **************************************************************
+   *****************************************************************************
+   */
+  describe('capabilities', () => {
+    it('should return undefined if drmSupport is not available', async () => {
+      player.drmSupport = undefined;
+      await expect(monitoring.capabilities()).resolves.toBeUndefined();
+    });
+
+    it('should return the drm capabilities', async () => {
+      player.drmSupport = {
+        check: jest.fn().mockResolvedValue({
+          widevine: { level: 'L3', hdcp: null },
+          playReady: null,
+          clearKey: {}
+        })
+      };
+
+      await expect(monitoring.capabilities()).resolves.toEqual({
+        widevine: {
+          level: 'L3', hdcp: null
+        }
+      });
     });
   });
 
@@ -201,7 +229,7 @@ describe('PillarboxMonitoring', () => {
    *****************************************************************************
    */
   describe('error', () => {
-    it('should send an error and reset the session', () => {
+    it('should send an error and reset the session', async () => {
       global.performance.getEntriesByType = jest.fn().mockReturnValue([]);
       player.error.mockReturnValueOnce({
         metadata: { hasSomething: true },
@@ -223,7 +251,7 @@ describe('PillarboxMonitoring', () => {
       const spyOnSendEvent = jest.spyOn(monitoring, 'sendEvent');
       const spyOnReset = jest.spyOn(monitoring, 'reset');
 
-      monitoring.error();
+      await monitoring.error();
 
       expect(spyOnSendEvent).toHaveBeenCalledWith('ERROR', expect.any(Object));
       expect(spyOnReset).toHaveBeenCalled();
@@ -356,7 +384,7 @@ describe('PillarboxMonitoring', () => {
    *****************************************************************************
    */
   describe('heartbeat', () => {
-    it('should send an HEARTBEAT when the time interval timeout has been reached', () => {
+    it('should send an HEARTBEAT when the time interval timeout has been reached', async () => {
       jest.useFakeTimers();
 
       const spyOnSendEvent = jest.spyOn(monitoring, 'sendEvent');
@@ -377,7 +405,7 @@ describe('PillarboxMonitoring', () => {
    *****************************************************************************
    */
   describe('loadedData', () => {
-    it('should send a START immediately followed by an HEARTBEAT', () => {
+    it('should send a START immediately followed by an HEARTBEAT', async () => {
       player.currentSource.mockReturnValue({
         mediaData: {}
       });
@@ -386,7 +414,7 @@ describe('PillarboxMonitoring', () => {
       const spyOnSendEvent = jest.spyOn(monitoring, 'sendEvent');
       const spyOnRandomUUID = jest.spyOn(PillarboxMonitoring, 'randomUUID').mockReturnValue(true);
 
-      monitoring.loadedData();
+      await monitoring.loadedData();
 
       expect(spyOnSendEvent).toHaveBeenCalledTimes(2);
       expect(spyOnSendEvent).toHaveBeenNthCalledWith(1, 'START', expect.any(Object));
@@ -548,7 +576,7 @@ describe('PillarboxMonitoring', () => {
    *****************************************************************************
    */
   describe('sendEvent', () => {
-    it('should send a POST request using sendBeacon', () => {
+    it('should send a POST request using sendBeacon', async () => {
       global.performance.getEntriesByType = jest.fn().mockReturnValue([]);
 
       const spyOnSendBeacon = jest.spyOn(navigator, 'sendBeacon');


### PR DESCRIPTION
## Description

Resolve #413 by including DRM data in the `START` event payload to help correlate playback issues with device DRM capabilities.

## Changes made

- update `pillarboxmonitoring.js` to add DRM capabilities to START payload
- add unit tests in `pillarbox-monitoring.spec.js`

