### PR TITLE
fix(drm-support): reduce console noise from DRM check errors

### DIFF
--- a/src/components/drm-support.js
+++ b/src/components/drm-support.js
@@ -100,7 +100,7 @@ class DrmSupport extends Component {
 
         return { level: label, hdcp };
       } catch (e) {
-        videojs.log.warn(
+        videojs.log.debug(
           'DrmSupport',
           `checkVendor failed (vendor=${vendor}, level=${label}, contentType=${contentType}, robustness=${robustness})`,
           e

--- a/test/components/drm-support.spec.js
+++ b/test/components/drm-support.spec.js
@@ -8,8 +8,6 @@ describe('DrmSupport', () => {
   let videoEl;
   let player;
 
-  pillarbox.log.warn = jest.fn().mockReturnValue({});
-
   beforeAll(() => {
     videoEl = document.createElement('video');
     videoEl.id = 'player';


### PR DESCRIPTION
## Description

Change error logging within the `check()` method to use debug-level messages. This prevents console pollution when DRM config errors occur, making logs less intrusive and only visible when debug severity is explicitly enabled.

<img width="1431" height="648" alt="image" src="https://github.com/user-attachments/assets/7214556d-e025-4cfc-9253-9d646443bd5f" />

## Changes made

- use `videojs.log.debug` instead of `videojs.log.warn`
- remove mock from unit tests since the debug mode doesn't print logs by default

