### PR TITLE
feat(monitoring): add player language code

### DIFF
--- a/src/trackers/PillarboxMonitoring.js
+++ b/src/trackers/PillarboxMonitoring.js
@@ -536,6 +536,7 @@ class PillarboxMonitoring {
    * Information about the player.
    *
    * @typedef {Object} PlayerInfo
+   * @property {string} language The language code of the player
    * @property {string} name The name of the player
    * @property {string} version The version of the player
    * @property {string} platform The platform on which the player is running
@@ -544,9 +545,10 @@ class PillarboxMonitoring {
    */
   playerInfo() {
     return {
+      language: this.player.language(),
       name: this.playerName,
+      platform: this.platform,
       version: this.playerVersion,
-      platform: this.platform
     };
   }
 

--- a/test/__mocks__/player-mock.js
+++ b/test/__mocks__/player-mock.js
@@ -12,6 +12,7 @@ let playerMock = jest.fn(() => ({
   }),
   debug: jest.fn().mockReturnValue(false),
   duration: jest.fn().mockReturnValue(0),
+  language: jest.fn(),
   liveTracker: {
     atLiveEdge: jest.fn(),
     liveCurrentTime: jest.fn(),


### PR DESCRIPTION
## Description

Resolves #396 by adding the player's language code to the player object, which could help better understand the playback session context.

## Changes made

- add the player's language code to `playerInfo`
- add language to the player mock

