### PR TITLE
feat(media-composition): expose the aspectRatio property

### DIFF
--- a/src/dataProvider/model/MediaComposition.js
+++ b/src/dataProvider/model/MediaComposition.js
@@ -225,6 +225,7 @@ class MediaComposition {
       analyticsMetadata: this.getMergedAnalyticsMetadata(
         resource.analyticsMetadata
       ),
+      aspectRatio: this.getMainChapter().aspectRatio,
       blockReason: this.getMainChapter().blockReason,
       blockedSegments: this.getMainBlockedSegments(),
       imageUrl: this.getMainChapterImageUrl(),


### PR DESCRIPTION
## Description

Resolves #415 by exposing the `aspectRatio` property on `mediaData`. This information may be useful depending on the integration use case.

## Changes made

- add the `aspectRatio` property to `getMainResources`

