### PR TITLE
feat(middleware): remove incompatible source filter

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -216,7 +216,7 @@ class SrgSsr {
   static composeMainResources(mediaComposition) {
     return this.composeAkamaiResources(
       this.composeKeySystemsResources(
-        this.filterIncompatibleResources(mediaComposition.getMainResources())
+        mediaComposition.getMainResources()
       )
     );
   }
@@ -381,19 +381,6 @@ class SrgSsr {
       message,
       metadata,
     });
-  }
-
-  /**
-   * Filter out incompatible resources such as `RTMP` and `HDS`.
-   *
-   * @param {Array.<MainResource>} resources Resources to filter
-   *
-   * @returns {Array.<MainResource>} The filtered resources
-   */
-  static filterIncompatibleResources(resources = []) {
-    return resources.filter(
-      (resource) => !['RTMP', 'HDS'].includes(resource.streaming)
-    );
   }
 
   /**

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -1220,37 +1220,6 @@ describe('SrgSsr', () => {
 
   /**
    *****************************************************************************
-   * filterIncompatibleResources ***********************************************
-   *****************************************************************************
-   */
-
-  describe('filterIncompatibleResources', () => {
-    it('should filter incompatible resources', async () => {
-      const resources = urnRtsAudio.chapterList[0].resourceList;
-      const filteredResources = SrgSsr.filterIncompatibleResources(resources);
-
-      expect(filteredResources).toHaveLength(2);
-    });
-
-    it('should return an empty array if no source is compatible', async () => {
-      const incompatibleResources = [
-        { streaming: 'HDS' },
-        { streaming: 'RTMP' }
-      ];
-      const filteredResources = SrgSsr.filterIncompatibleResources(
-        incompatibleResources
-      );
-
-      expect(filteredResources).toHaveLength(0);
-    });
-
-    it('should return an empty array the resource is undefined', async () => {
-      expect(SrgSsr.filterIncompatibleResources()).toHaveLength(0);
-    });
-  });
-
-  /**
-   *****************************************************************************
    * srgAnalytics **************************************************************
    *****************************************************************************
    */


### PR DESCRIPTION
## Description

Resolves #414 by removing the incompatible resources filter, since this work is now done by the backend.

ref: https://srgssr-ch.atlassian.net/browse/PLAYNEXT-7740

## Changes made

- remove the `filterIncompatibleResources` method from middleware
- remove the unit tests related to `filterIncompatibleResources`