### PR TITLE
feat(middleware): add data provider http headers property options

### DIFF
--- a/docs/api/tutorials/Options.md
+++ b/docs/api/tutorials/Options.md
@@ -109,6 +109,69 @@ ensure proper media playback.
 
 > The absence of a conforming object may lead to unexpected errors, affecting video playback.
 
+### `srgOptions.dataProviderHeaders`
+
+***Specific to media content from SRG SSR.***
+
+Specifies custom HTTP headers to be sent with every request made by the data provider. This is useful for providing additional context to the server.
+
+#### Usage
+
+You can provide headers as a plain JavaScript object or as a `Headers` object.
+
+##### Using a plain object
+
+When using a plain object, Pillarbox creates a copy of it. If you need to modify the headers after initialization, you must update the player's options.
+
+```javascript
+const headersObj = {
+  'Accept-Language': 'de',
+};
+
+const player = pillarbox('player', {
+  srgOptions: {
+    // Defines custom headers for the data provider
+    dataProviderHeaders: headersObj,
+  }
+});
+
+// The data provider will use 'Accept-Language: de'
+player.src({ src: 'urn:rts:video:9883196', type: 'srgssr/urn' });
+
+// To update the headers, modify the object and re-apply the options
+headersObj['Accept-Language'] = 'it';
+player.options({
+  srgOptions: {
+    dataProviderHeaders: headersObj,
+  },
+});
+
+// The data provider will now use 'Accept-Language: it'
+player.src({ src: 'urn:rts:video:9883196', type: 'srgssr/urn' });
+```
+
+##### Using a Headers object
+
+When using a `Headers` object, Pillarbox uses the reference to the object. Any modifications to the `Headers` object will be automatically reflected in subsequent data provider requests.
+
+```javascript
+const headers = new Headers({ 'Accept-Language': 'fr' });
+const player = pillarbox('player', {
+  srgOptions: {
+    dataProviderHeaders: headers,
+  },
+});
+
+// The data provider will use 'Accept-Language: fr'
+player.src({ src: 'urn:rts:video:9883196', type: 'srgssr/urn' });
+
+// Update the header
+headers.set('Accept-Language', 'rm');
+
+// The data provider will now automatically use 'Accept-Language: rm'
+player.src({ src: 'urn:rts:video:9883196', type: 'srgssr/urn' });
+```
+
 ### `srgOptions.dataProviderHost`
 
 ***Specific to media content from SRG SSR.***

--- a/src/dataProvider/services/DataProvider.js
+++ b/src/dataProvider/services/DataProvider.js
@@ -29,13 +29,16 @@ class DataProvider {
    * This provides unified error handling, regardless of the urlHandler used.
    *
    * @param {Function} urlHandler A function that constructs the URL
+   * @param {Object<string, string>|Headers} headers An object containing HTTP headers to be sent with the request
    *
    * @returns {Promise<MediaComposition>} A promise with the fetched data
    */
-  handleRequest(urlHandler) {
+  handleRequest(urlHandler, headers) {
     return async (urn) => {
       const url = typeof urlHandler === 'function' ? urlHandler(urn) : this.mediaCompositionUrlHandler(urn);
-      const response = await fetch(url);
+      const response = await fetch(url, {
+        headers
+      });
 
       if (!response.ok) {
         throw response;

--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -322,12 +322,13 @@ class SrgSsr {
   static dataProvider(player) {
     if (!player.options().srgOptions.dataProvider) {
       const {
+        dataProviderHeaders,
         dataProviderHost,
         dataProviderUrlHandler
       } = player.options().srgOptions;
       const dataProvider = new DataProvider(dataProviderHost);
       const requestHandler = dataProvider
-        .handleRequest(dataProviderUrlHandler);
+        .handleRequest(dataProviderUrlHandler, dataProviderHeaders);
 
       player.options({
         srgOptions: {

--- a/test/dataProvider/services/DataProvider.spec.js
+++ b/test/dataProvider/services/DataProvider.spec.js
@@ -47,5 +47,17 @@ describe('DataProvider', () => {
 
       await expect(requestHandler(urnNotFound)).rejects.not.toBeNull();
     });
+
+    it('should use headers when provided', async () => {
+      const headers = { 'Accept-Language': 'jp' };
+      const requestHandler = dataproviderService.handleRequest(
+        undefined,
+        headers
+      );
+
+      await requestHandler(urn10272382);
+
+      expect(fetch).toHaveBeenCalledWith(expect.any(String), { headers });
+    });
   });
 });


### PR DESCRIPTION
## Description

Resolves #421 by allowing to specify custom HTTP headers to be sent with every request made by the data provider. This is useful for providing additional context to the server.

## Changes made

- update DataProvider.handleRequest to accept a headers parameter
- update SrgSsr.dataProvider to use the dataProviderHeaders option
- add test cases for DataProvider
- add documentation for the new option

