### PR TITLE
feat(data-provider): drm resource selection

### DIFF
--- a/src/dataProvider/services/DataProvider.js
+++ b/src/dataProvider/services/DataProvider.js
@@ -28,14 +28,15 @@ class DataProvider {
    *
    * This provides unified error handling, regardless of the urlHandler used.
    *
-   * @param {Function} urlHandler A function that constructs the URL
+   * @param {function(string, Object): string} urlHandler A function that constructs the URL
    * @param {Object<string, string>|Headers} headers An object containing HTTP headers to be sent with the request
+   * @param {Object<string, string>} queryParams The query params to be passed to the request URL
    *
    * @returns {Promise<MediaComposition>} A promise with the fetched data
    */
-  handleRequest(urlHandler, headers) {
+  handleRequest(urlHandler, headers, queryParams) {
     return async (urn) => {
-      const url = typeof urlHandler === 'function' ? urlHandler(urn) : this.mediaCompositionUrlHandler(urn);
+      const url = typeof urlHandler === 'function' ? urlHandler(urn, queryParams) : this.mediaCompositionUrlHandler(urn, queryParams);
       const response = await fetch(url, {
         headers
       });
@@ -55,11 +56,23 @@ class DataProvider {
    * Gets the media composition URL by URN.
    *
    * @param {string} urn The URN for the media composition
+   * @param {Object<string, string>} [queryParams] The query params to be passed to the request URL
    *
-   * @returns {string} The constructed URL
+   * @returns {URL} The constructed URL
    */
-  mediaCompositionUrlHandler(urn) {
-    return `https://${this.baseUrl}mediaComposition/byUrn/${urn}?onlyChapters=true&vector=portalplay`;
+  mediaCompositionUrlHandler(urn, queryParams) {
+    const url = new URL(`https://${this.baseUrl}mediaComposition/byUrn/${urn}`);
+
+    if (queryParams) {
+      Object
+        .entries(queryParams)
+        .forEach(([key, value]) => url.searchParams.set(key, value));
+    }
+
+    url.searchParams.set('onlyChapters', 'true');
+    url.searchParams.set('vector', 'portalplay');
+
+    return url;
   }
 }
 

--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -319,7 +319,7 @@ class SrgSsr {
    *
    * @returns {DataProvider}
    */
-  static dataProvider(player) {
+  static dataProvider(player, drmCapability) {
     if (!player.options().srgOptions.dataProvider) {
       const {
         dataProviderHeaders,
@@ -328,7 +328,11 @@ class SrgSsr {
       } = player.options().srgOptions;
       const dataProvider = new DataProvider(dataProviderHost);
       const requestHandler = dataProvider
-        .handleRequest(dataProviderUrlHandler, dataProviderHeaders);
+        .handleRequest(
+          dataProviderUrlHandler,
+          dataProviderHeaders,
+          drmCapability
+        );
 
       player.options({
         srgOptions: {
@@ -366,6 +370,26 @@ class SrgSsr {
     });
 
     return true;
+  }
+
+  /**
+   * Checks the player's DRM support and returns the supported vendors
+   * with their security levels.
+   *
+   * @param {Object} player the player instance
+   *
+   * @returns {Promise<Object<string, string>|undefined>} DRM capability with format { drmPlayerCapabilities: "{vendor};{level},..." }, or undefined
+   */
+  static async drmCapability(player) {
+    if (!player.drmSupport) return undefined;
+
+    const capabilities = Object
+      .entries(await player.drmSupport.check())
+      .filter(([key, value]) => Drm.vendors[key.toUpperCase()] && value)
+      .map(([key, value]) => `${Drm.vendors[key.toUpperCase()]};${value.level}`)
+      .join(',');
+
+    return capabilities ? { drmPlayerCapabilities: capabilities } : undefined;
   }
 
   /**
@@ -481,19 +505,26 @@ class SrgSsr {
   }
 
   /**
-   * Get the mediaData most likely to be compatible depending on the browser.
+   * Get the mediaData from a mediaComposition.
    *
-   * @param {Array.<MainResourceWithKeySystems>} resources
+   * @param {MediaComposition} mediaComposition
    *
-   * @returns {MainResourceWithKeySystems} By default, the first entry is used if none is compatible.
+   * @returns {Promise<MainResourceWithKeySystems|MainResource|undefined>}
    */
-  static getMediaData(resources = []) {
-    if (AkamaiTokenService.hasToken(resources)) return resources[0];
+  static async getMediaData(mediaComposition) {
+    if (!mediaComposition) return undefined;
 
-    const type = Pillarbox.browser.IS_ANY_SAFARI ? 'HLS' : 'DASH';
-    const resource = resources.find(({ streaming }) => streaming === type);
+    const [mediaData] =
+      (await this.composeMainResources(mediaComposition)) || [];
 
-    return resource || resources[0];
+    if (!mediaData) {
+      return {
+        blockReason: mediaComposition.getMainChapter().blockReason,
+        imageUrl: mediaComposition.getMainChapterImageUrl(),
+      };
+    }
+
+    return mediaData;
   }
 
   /**
@@ -510,21 +541,12 @@ class SrgSsr {
     }
 
     const { src: urn, ...srcOptions } = srcObj;
+    const drmCapability = await this.drmCapability(player);
     const mediaComposition = await this.getMediaComposition(
       urn,
-      this.dataProvider(player)
+      await this.dataProvider(player, drmCapability)
     );
-    const mainResources = await this.composeMainResources(
-      mediaComposition
-    );
-    let mediaData = this.getMediaData(mainResources);
-
-    if (!mediaData) {
-      mediaData = {
-        blockReason: mediaComposition.getMainChapter().blockReason,
-        imageUrl: mediaComposition.getMainChapterImageUrl(),
-      };
-    }
+    const mediaData = await this.getMediaData(mediaComposition);
 
     return this.composeSrcMediaData(srcOptions, mediaData);
   }

--- a/test/__mocks__/fetch.js
+++ b/test/__mocks__/fetch.js
@@ -18,6 +18,7 @@ const urns = {
 
 const fetch = jest.fn((url, onlyChapters) => {
   const urn = url
+    .toString()
     .split('/')
     .pop()
     .split('?')[0];

--- a/test/dataProvider/services/DataProvider.spec.js
+++ b/test/dataProvider/services/DataProvider.spec.js
@@ -23,23 +23,57 @@ describe('DataProvider', () => {
    *****************************************************************************
    */
   describe('handleRequest', () => {
-    it('should use the default URL handler when the urlHandler is undefined', () => {
+    it('should use the default URL handler when the urlHandler is undefined', async () => {
       const spyOnMediaCompositionUrlHandler = jest.spyOn(dataproviderService, 'mediaCompositionUrlHandler');
 
       const defaultRequestHandler = dataproviderService.handleRequest();
 
-      defaultRequestHandler(urn10272382);
+      await defaultRequestHandler(urn10272382);
 
-      expect(spyOnMediaCompositionUrlHandler).toHaveBeenCalledWith(urn10272382);
+      expect(spyOnMediaCompositionUrlHandler).toHaveBeenCalledWith(urn10272382, undefined);
+    });
+
+    it('should forward queryParams to the default URL handler when urlHandler is undefined', async () => {
+      const spyOnMediaCompositionUrlHandler = jest.spyOn(
+        dataproviderService,
+        'mediaCompositionUrlHandler'
+      );
+      const queryParams = { stamina: '420', shield: '69' };
+      const defaultRequestHandler = dataproviderService.handleRequest(
+        undefined,
+        undefined,
+        queryParams
+      );
+
+      await defaultRequestHandler(urn10272382);
+
+      expect(spyOnMediaCompositionUrlHandler).toHaveBeenCalledWith(
+        urn10272382,
+        queryParams
+      );
     });
 
     it('should not use the default URL handler if urlHandler is defined', () => {
       const spyOnMediaCompositionUrlHandler = jest.spyOn(dataproviderService, 'mediaCompositionUrlHandler');
-      const defaultRequestHandler = dataproviderService.handleRequest((urn)=> urn);
+      const defaultRequestHandler = dataproviderService.handleRequest((urn) => urn);
 
       defaultRequestHandler(urn10272382);
 
       expect(spyOnMediaCompositionUrlHandler).not.toHaveBeenCalled();
+    });
+
+    it('should forward queryParams to the custom urlHandler if urlHandler is defined', async () => {
+      const customUrlHandler = jest.fn((urn, _queryParams) => urn);
+      const queryParams = { stamina: '420', shield: '69' };
+      const requestHandler = dataproviderService.handleRequest(
+        customUrlHandler,
+        undefined,
+        queryParams
+      );
+
+      await requestHandler(urn10272382);
+
+      expect(customUrlHandler).toHaveBeenCalledWith(urn10272382, queryParams);
     });
 
     it('should throw an error if the urn does not exist', async () => {
@@ -57,7 +91,46 @@ describe('DataProvider', () => {
 
       await requestHandler(urn10272382);
 
-      expect(fetch).toHaveBeenCalledWith(expect.any(String), { headers });
+      expect(fetch).toHaveBeenCalledWith(expect.any(URL), { headers });
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * mediaCompositionUrlHandler ************************************************
+   *****************************************************************************
+   */
+  describe('mediaCompositionUrlHandler', () => {
+    it('should return the default URL when queryParams is undefined', () => {
+      const url = dataproviderService.mediaCompositionUrlHandler(urn10272382);
+      const expectedUrl = `https://il.srgssr.ch/integrationlayer/2.1/mediaComposition/byUrn/${urn10272382}?onlyChapters=true&vector=portalplay`;
+
+      expect(url).toBeInstanceOf(URL);
+      expect(url.toString()).toBe(expectedUrl);
+    });
+
+    it('should append queryParams to the URL', () => {
+      const queryParams = { stamina: '420', shield: '69' };
+      const url = dataproviderService.mediaCompositionUrlHandler(
+        urn10272382,
+        queryParams
+      );
+      const expectedUrl = `https://il.srgssr.ch/integrationlayer/2.1/mediaComposition/byUrn/${urn10272382}?stamina=420&shield=69&onlyChapters=true&vector=portalplay`;
+
+      expect(url).toBeInstanceOf(URL);
+      expect(url.toString()).toBe(expectedUrl);
+    });
+
+    it('should not allow queryParams to override default parameters', () => {
+      const queryParams = { onlyChapters: 'false', vector: 'custom' };
+      const url = dataproviderService.mediaCompositionUrlHandler(
+        urn10272382,
+        queryParams
+      );
+      const expectedUrl = `https://il.srgssr.ch/integrationlayer/2.1/mediaComposition/byUrn/${urn10272382}?onlyChapters=true&vector=portalplay`;
+
+      expect(url).toBeInstanceOf(URL);
+      expect(url.toString()).toBe(expectedUrl);
     });
   });
 });

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -3,7 +3,6 @@ import DataProvider from '../../src/dataProvider/services/DataProvider.js';
 import Image from '../../src/utils/Image.js';
 import MediaComposition from '../../src/dataProvider/model/MediaComposition.js';
 import urnCredits from '../__mocks__/urn:rts:video:10313496-credits.json';
-import urnRtsAudio from '../__mocks__/urn:rts:audio:3262320.json';
 import urnGeoblockAndUndefinedResourceList from '../__mocks__/urn:geoblock:and:undefined:resourcelist.json';
 import srcMediaObj from '../__mocks__/srcMediaObj.json';
 import mainResource from '../__mocks__/mainResource.json';
@@ -66,6 +65,9 @@ describe('SrgSsr', () => {
       }),
       currentTime: jest.fn(),
       debug: jest.fn(),
+      drmSupport: {
+        check: jest.fn().mockResolvedValue({}),
+      },
       error: jest.fn(),
       localize: jest.fn(),
       on: jest.fn(),
@@ -665,6 +667,37 @@ describe('SrgSsr', () => {
 
   /**
    *****************************************************************************
+   * composeMainResources ******************************************************
+   *****************************************************************************
+   */
+  describe('composeMainResources', () => {
+    it('should return the composed main resources for a mediaComposition', async () => {
+      const mediaComposition = Object.assign(
+        new MediaComposition(),
+        urnCredits
+      );
+      const resources = await SrgSsr.composeMainResources(mediaComposition);
+
+      expect(resources).toEqual(expect.any(Array));
+      expect(resources[0]).toMatchObject({
+        streaming: 'HLS',
+        tokenType: 'NONE',
+      });
+    });
+
+    it('should return an empty array when the mediaComposition does not contain resources', async () => {
+      const mediaComposition = Object.assign(
+        new MediaComposition(),
+        urnGeoblockAndUndefinedResourceList
+      );
+      const resources = await SrgSsr.composeMainResources(mediaComposition);
+
+      expect(resources).toEqual([]);
+    });
+  });
+
+  /**
+   *****************************************************************************
    * composeSrcMediaData *******************************************************
    *****************************************************************************
    */
@@ -875,6 +908,23 @@ describe('SrgSsr', () => {
 
       expect(DataProvider).toHaveBeenCalledTimes(1);
     });
+
+    it('should pass drmCapability to handleRequest when instantiating the dataProvider', () => {
+      const drmCapability = { drmPlayerCapabilities: 'com.widevine.alpha;L1' };
+      const mockHandleRequest = jest.fn();
+
+      DataProvider.mockImplementationOnce(() => ({
+        handleRequest: mockHandleRequest,
+      }));
+
+      SrgSsr.dataProvider(player, drmCapability);
+
+      expect(mockHandleRequest).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        drmCapability
+      );
+    });
   });
 
   /**
@@ -901,6 +951,66 @@ describe('SrgSsr', () => {
         })
       ).toBe(true);
       expect(spyOnError).toHaveBeenCalledWith(player, expect.any(Object));
+    });
+  });
+
+  /**
+   *****************************************************************************
+   * drmCapability *************************************************************
+   *****************************************************************************
+   */
+  describe('drmCapability', () => {
+    it('should return undefined if drmSupport is not available on player', async () => {
+      expect(await SrgSsr.drmCapability({})).toBeUndefined();
+    });
+
+    it('should return undefined if no supported DRM vendor is found', async () => {
+      const fakePlayer = {
+        drmSupport: {
+          check: jest.fn().mockResolvedValue({
+            widevine: null,
+            fairplay: null,
+            playready: null,
+            clearKey: { level: 'Supported', hdcp: null },
+          }),
+        },
+      };
+
+      expect(await SrgSsr.drmCapability(fakePlayer)).toBeUndefined();
+    });
+
+    it('should return the DRM capability for a single supported vendor', async () => {
+      const fakePlayer = {
+        drmSupport: {
+          check: jest.fn().mockResolvedValue({
+            widevine: { level: 'L1', hdcp: '2.2' },
+            playready: null,
+            fairplay: null,
+          }),
+        },
+      };
+
+      expect(await SrgSsr.drmCapability(fakePlayer)).toEqual({
+        drmPlayerCapabilities: 'com.widevine.alpha;L1',
+      });
+    });
+
+    it('should return DRM capabilities separated by a comma when multiple vendors are supported', async () => {
+      const fakePlayer = {
+        drmSupport: {
+          check: jest.fn().mockResolvedValue({
+            widevine: { level: 'L1', hdcp: '2.2' },
+            playready: { level: 'SL3000', hdcp: '2.2' },
+            fairplay: null,
+            clearKey: { level: 'Supported', hdcp: null },
+          }),
+        },
+      };
+
+      expect(await SrgSsr.drmCapability(fakePlayer)).toEqual({
+        drmPlayerCapabilities:
+          'com.widevine.alpha;L1,com.microsoft.playready;SL3000',
+      });
     });
   });
 
@@ -1111,51 +1221,28 @@ describe('SrgSsr', () => {
    *****************************************************************************
    */
   describe('getMediaData', () => {
-    it('should return the first resource when there is a tokenType', () => {
-      const resources = [
-        { streaming: 'HLS', tokenType: 'AKAMAI', isFirst: true },
-        { streaming: 'HLS', tokenType: 'AKAMAI', isFirst: false }
-      ];
-      const resource = SrgSsr.getMediaData(resources);
+    it('should return the first composed main resource from a mediaComposition', async () => {
+      const mediaComposition = Object.assign(new MediaComposition(), urnCredits);
+      const resource = await SrgSsr.getMediaData(mediaComposition);
 
       expect(resource).toMatchObject({
         streaming: 'HLS',
-        tokenType: 'AKAMAI',
-        isFirst: true,
+        tokenType: 'NONE',
       });
     });
 
-    it('should return an HLS resource if available for any Safari browser', () => {
-      const mockIsAnySafari = jest.replaceProperty(Pillarbox, 'browser', {
-        IS_ANY_SAFARI: true,
+    it('should return a fallback mediaData containing a blocking reason when the mediaComposition does not contain resources', async () => {
+      const mediaComposition = Object.assign(new MediaComposition(), urnGeoblockAndUndefinedResourceList);
+      const resource = await SrgSsr.getMediaData(mediaComposition);
+
+      expect(resource).toEqual({
+        blockReason: 'GEOBLOCK',
+        imageUrl: 'https://img.rts.ch/medias/2023/image/y2zvzo-26927888.image/16x9',
       });
-      const resources = [{ streaming: 'DASH' }, { streaming: 'HLS' }];
-      const resource = SrgSsr.getMediaData(resources);
-
-      expect(resource).toMatchObject({ streaming: 'HLS' });
-      mockIsAnySafari.restore();
     });
 
-    it('should return a DASH resource if available for any browser other than Safari', () => {
-      const resources = [{ streaming: 'HLS' }, { streaming: 'DASH' }];
-      const resource = SrgSsr.getMediaData(resources);
-
-      expect(resource).toMatchObject({ streaming: 'DASH' });
-    });
-
-    it('should default to the first available resource if no better resource is available', () => {
-      const resources = [
-        { streaming: 'HLS', isFirst: true },
-        { streaming: 'HLS', isFirst: false }
-      ];
-      const resource = SrgSsr.getMediaData(resources);
-
-      expect(resource).toMatchObject({ streaming: 'HLS', isFirst: true });
-    });
-
-    it('should return undefined if the resources are not defined or if the array is empty', () => {
-      expect(SrgSsr.getMediaData([])).toBeUndefined();
-      expect(SrgSsr.getMediaData()).toBeUndefined();
+    it('should return undefined if mediaComposition is undefined', async () => {
+      expect(await SrgSsr.getMediaData()).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Description

Resolves #412 by delegating resource selection to the backend and providing
the user's DRM capabilities. This also allows us to remove the resource
filtering performed by the middleware based on the browser type.

## Changes made

- add a query parameter to the data provider
- add DRM capability detection to the middleware
- update the middleware's dataProvider function to handle DRM capabilities
- remove resource filtering based on the browser type
- repurpose getMediaData to extract some logic from getSrcMediaObj
- add unit tests
- remove test cases related to resource filtering based on the browser type

