### PR TITLE
fix(middleware): handle legacy FairPlay license URI

### DIFF
--- a/src/middleware/srgssr.js
+++ b/src/middleware/srgssr.js
@@ -191,15 +191,22 @@ class SrgSsr {
    * if at least one of them has DRM.
    *
    * @param {Array.<MainResource>} resources
+   * @param {Player} player the player instance
    *
    * @returns {Array.<MainResourceWithKeySystems>}
    */
-  static composeKeySystemsResources(resources = []) {
+  static composeKeySystemsResources(resources = [], player) {
     if (!Drm.hasDrm(resources)) return resources;
+
+    const isLegacyFairplay = Boolean(
+      player &&
+      player.eme &&
+      player.eme.legacyFairplayIsUsed
+    );
 
     const resourcesWithKeySystems = resources.map((resource) => ({
       ...resource,
-      ...Drm.buildKeySystems(resource.drmList),
+      ...Drm.buildKeySystems(resource.drmList, isLegacyFairplay),
     }));
 
     return resourcesWithKeySystems;
@@ -210,13 +217,15 @@ class SrgSsr {
    * May add an Akamai token or key systems if required by the resource.
    *
    * @param {MediaComposition} mediaComposition
+   * @param {Player} player the player instance
    *
    * @returns {Promise<Array.<MainResourceWithKeySystems>>}
    */
-  static composeMainResources(mediaComposition) {
+  static composeMainResources(mediaComposition, player) {
     return this.composeAkamaiResources(
       this.composeKeySystemsResources(
-        mediaComposition.getMainResources()
+        mediaComposition.getMainResources(),
+        player
       )
     );
   }
@@ -508,14 +517,15 @@ class SrgSsr {
    * Get the mediaData from a mediaComposition.
    *
    * @param {MediaComposition} mediaComposition
+   * @param {Player} player the player instance
    *
    * @returns {Promise<MainResourceWithKeySystems|MainResource|undefined>}
    */
-  static async getMediaData(mediaComposition) {
+  static async getMediaData(mediaComposition, player) {
     if (!mediaComposition) return undefined;
 
     const [mediaData] =
-      (await this.composeMainResources(mediaComposition)) || [];
+      (await this.composeMainResources(mediaComposition, player)) || [];
 
     if (!mediaData) {
       return {
@@ -546,7 +556,7 @@ class SrgSsr {
       urn,
       await this.dataProvider(player, drmCapability)
     );
-    const mediaData = await this.getMediaData(mediaComposition);
+    const mediaData = await this.getMediaData(mediaComposition, player);
 
     return this.composeSrcMediaData(srcOptions, mediaData);
   }

--- a/src/utils/Drm.js
+++ b/src/utils/Drm.js
@@ -12,17 +12,18 @@ class Drm {
    * Build the keySystems object according to the DRM vendor.
    *
    * @param {Array.<import('../dataProvider/model/typedef').DrmMetadata>} drmList The DRM list from the media composition.
+   * @param {boolean} [isLegacyFairplay=false] whether legacy FairPlay is used
    *
    * @returns {import('./typedef').KeySystems} The resulting keySystems.
    */
-  static buildKeySystems(drmList = []) {
+  static buildKeySystems(drmList = [], isLegacyFairplay = false) {
     const keySystems = {};
 
     drmList.forEach((drmVendor) => {
       const type = Drm.vendors[drmVendor.type];
 
       if (Drm.vendors.FAIRPLAY === type) {
-        keySystems[type] = Drm.buildFairplayConfig(drmVendor);
+        keySystems[type] = Drm.buildFairplayConfig(drmVendor, isLegacyFairplay);
       } else {
         keySystems[type] = drmVendor.licenseUrl;
       }
@@ -37,10 +38,11 @@ class Drm {
    * Builds the configuration for Apple FairPlay.
    *
    * @param {import('../dataProvider/model/typedef').DrmMetadata} drmVendor the DRM metadata for FairPlay
+   * @param {boolean} [isLegacyFairplay=false] whether legacy FairPlay is used
    *
    * @returns {import('./typedef').KeySystemConfiguration} the FairPlay configuration
    */
-  static buildFairplayConfig(drmVendor) {
+  static buildFairplayConfig(drmVendor, isLegacyFairplay = false) {
     const { certificateUrl: certificateUri } = drmVendor;
 
     return {
@@ -49,7 +51,11 @@ class Drm {
         return contentId.replace('skd:', 'https:');
       },
       getLicense: function (emeOptions, licenseUri, keyMessage, callback) {
-        Drm.requestLicense(licenseUri, keyMessage, callback);
+        const uri = isLegacyFairplay
+          ? licenseUri.slice(licenseUri.indexOf('https:'))
+          : licenseUri;
+
+        Drm.requestLicense(uri, keyMessage, callback);
       }
     };
   }

--- a/test/middleware/srgssr.spec.js
+++ b/test/middleware/srgssr.spec.js
@@ -8,6 +8,7 @@ import srcMediaObj from '../__mocks__/srcMediaObj.json';
 import mainResource from '../__mocks__/mainResource.json';
 import Pillarbox from '../../src/pillarbox.js';
 import AkamaiTokenService from '../../src/utils/AkamaiTokenService.js';
+import Drm from '../../src/utils/Drm.js';
 import pillarbox from '../../src/pillarbox.js';
 
 jest.mock('../../src/dataProvider/services/DataProvider.js');
@@ -67,6 +68,9 @@ describe('SrgSsr', () => {
       debug: jest.fn(),
       drmSupport: {
         check: jest.fn().mockResolvedValue({}),
+      },
+      eme: {
+        legacyFairplayIsUsed : false
       },
       error: jest.fn(),
       localize: jest.fn(),
@@ -662,6 +666,28 @@ describe('SrgSsr', () => {
         SrgSsr.composeKeySystemsResources(resources);
 
       expect(resourcesWithKeySystems).toMatchObject(expectedResources);
+    });
+
+    it('should handle legacy FairPlay when player.eme.legacyFairplayIsUsed is true', () => {
+      const spyOnBuildKeySystems = jest.spyOn(Drm, 'buildKeySystems');
+      const drmList = [
+        {
+          type: 'FAIRPLAY',
+          licenseUrl: 'https://ze.license.url',
+          certificateUrl: 'https://ze.certificate.url',
+        }
+      ];
+      const resources = [{ streaming: 'HLS', drmList }];
+
+      // update default value
+      player.eme.legacyFairplayIsUsed = true;
+
+      SrgSsr.composeKeySystemsResources(resources, player);
+
+      expect(spyOnBuildKeySystems).toHaveBeenCalledWith(drmList, true);
+
+      // restore default value
+      player.eme.legacyFairplayIsUsed = false;
     });
   });
 

--- a/test/utils/Drm.spec.js
+++ b/test/utils/Drm.spec.js
@@ -64,6 +64,51 @@ describe('Drm', () => {
 
       expect(config.getContentId(null, 'skd://my-license-url')).toBe('https://my-license-url');
     });
+
+    it('should remove any chars before https: in licenseUri when isLegacyFairplay is true', () => {
+      const spyOnRequestLicense = jest.spyOn(Drm, 'requestLicense')
+        .mockImplementation();
+      const config = Drm.buildFairplayConfig(
+        { certificateUrl: 'https://ze.cert.url' },
+        true
+      );
+      const callback = jest.fn();
+
+      config.getLicense(
+        null,
+        'anyCharshttps://ze.license.url',
+        'keyMessage',
+        callback
+      );
+
+      expect(spyOnRequestLicense).toHaveBeenCalledWith(
+        'https://ze.license.url',
+        'keyMessage',
+        callback
+      );
+
+      spyOnRequestLicense.mockRestore();
+    });
+
+    it('should pass licenseUri as-is when isLegacyFairplay is false', () => {
+      const spyOnRequestLicense = jest.spyOn(Drm, 'requestLicense')
+        .mockImplementation();
+      const buildFairplayConfig = Drm.buildFairplayConfig(
+        { certificateUrl: 'https://ze.cert.url' },
+        false
+      );
+      const callback = jest.fn();
+
+      buildFairplayConfig.getLicense(null, 'Ãhttps://ze.license.url', 'keyMessage', callback);
+
+      expect(spyOnRequestLicense).toHaveBeenCalledWith(
+        'Ãhttps://ze.license.url',
+        'keyMessage',
+        callback
+      );
+
+      spyOnRequestLicense.mockRestore();
+    });
   });
 
   /**


### PR DESCRIPTION
## Description

When using `initLegacyFairplay`, the licenseUri received in `getLicense` contains special characters before the actual URL, which causes the DRM license request to fail.

## Changes made

- detect legacy FairPlay usage from `player.eme.legacyFairplayIsUsed`
- pass the `isLegacyFairplay` flag through `composeKeySystemsResources` and `buildKeySystems`
- sanitize the `licenseUri` in `buildFairplayConfig` when `isLegacyFairplay` is true
- add unit tests covering legacy and standard FairPlay license URI handling
